### PR TITLE
Add AFK detection and auto-kick system

### DIFF
--- a/gobds/afk.go
+++ b/gobds/afk.go
@@ -1,0 +1,118 @@
+package gobds
+
+import (
+	"context"
+	"sort"
+	"time"
+
+	"github.com/sandertv/gophertunnel/minecraft/text"
+	"github.com/smell-of-curry/gobds/gobds/session"
+)
+
+// afkEvaluatorInterval is how often the AFK evaluator ticks. Movement is
+// tracked per-packet on the session itself so 2s is plenty of granularity.
+const afkEvaluatorInterval = 2 * time.Second
+
+// afkCandidate pairs a session with its current idle duration so the evaluator
+// can sort and filter without re-reading the session state more than once.
+type afkCandidate struct {
+	s   *session.Session
+	dur time.Duration
+}
+
+// afkEvaluator runs per-Server for the lifetime of the listen loop. It sends
+// soft warnings regardless of fullness, and only escalates to the final
+// warning and actual kicks when the server is at or above the configured
+// fullness threshold. When kicking, the longest-AFK sessions go first.
+func (gb *GoBDS) afkEvaluator(srv *Server, ctx context.Context) {
+	timer := gb.conf.AFKTimer
+	if timer == nil {
+		return
+	}
+
+	t := time.NewTicker(afkEvaluatorInterval)
+	defer t.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-gb.ctx.Done():
+			return
+		case <-t.C:
+			gb.evaluateAFK(srv)
+		}
+	}
+}
+
+// evaluateAFK performs a single pass over the server's sessions.
+func (gb *GoBDS) evaluateAFK(srv *Server) {
+	timer := gb.conf.AFKTimer
+	sessions := srv.Sessions()
+	if len(sessions) == 0 {
+		return
+	}
+
+	cands := make([]afkCandidate, 0, len(sessions))
+	for _, s := range sessions {
+		cands = append(cands, afkCandidate{s: s, dur: s.AFKDuration()})
+	}
+
+	// Soft warnings always fire regardless of fullness. They only fire once
+	// per idle streak because the flags are reset on movement.
+	for _, c := range cands {
+		if c.dur >= timer.WarnApproaching && !c.s.WarnedApproaching() {
+			c.s.Message(text.Colourf("<yellow>You will be marked AFK in 1 minute. Move to reset your timer.</yellow>"))
+			c.s.SetWarnedApproaching(true)
+		}
+		if c.dur >= timer.MarkAFK && !c.s.MarkedAFK() {
+			c.s.Message(text.Colourf("<gold>You are now AFK. Move to reset your timer.</gold>"))
+			c.s.SetMarkedAFK(true)
+		}
+	}
+
+	if srv.StatusProvider == nil {
+		return
+	}
+	status := srv.StatusProvider.ServerStatus(-1, -1)
+	if status.MaxPlayers <= 0 {
+		return
+	}
+	fullness := float64(status.PlayerCount) / float64(status.MaxPlayers)
+	if fullness < timer.FullnessThreshold {
+		return
+	}
+
+	for _, c := range cands {
+		if c.dur >= timer.FinalWarning && !c.s.WarnedFinal() {
+			c.s.Message(text.Colourf("<red>Server is near capacity. Move now or you will be kicked for being AFK.</red>"))
+			c.s.SetWarnedFinal(true)
+		}
+	}
+
+	// Only sessions that are past the kick threshold are eligible, sorted
+	// longest-AFK first so the most-idle players go before the borderline ones.
+	eligible := cands[:0:0]
+	for _, c := range cands {
+		if c.dur >= timer.TimeoutDuration {
+			eligible = append(eligible, c)
+		}
+	}
+	if len(eligible) == 0 {
+		return
+	}
+	sort.Slice(eligible, func(i, j int) bool { return eligible[i].dur > eligible[j].dur })
+
+	// Use a local counter because the upstream StatusProvider is foreign and
+	// only refreshes periodically; without this we'd keep kicking until every
+	// eligible AFK player is gone.
+	threshold := int(float64(status.MaxPlayers) * timer.FullnessThreshold)
+	remaining := status.PlayerCount
+	for _, c := range eligible {
+		if remaining < threshold {
+			return
+		}
+		c.s.Disconnect(text.Colourf("<red>You've been kicked for being AFK.</red>"))
+		remaining--
+	}
+}

--- a/gobds/gobds.go
+++ b/gobds/gobds.go
@@ -87,6 +87,7 @@ func (gb *GoBDS) listen(srv *Server) {
 		return
 	}
 	go gb.claimFetching(srv)
+	go gb.afkEvaluator(srv, ctx)
 
 	go func() {
 		<-gb.ctx.Done()
@@ -112,8 +113,10 @@ func (gb *GoBDS) listen(srv *Server) {
 				return
 			}
 
+			srv.AddSession(s)
 			srv.Log.Info("player connected", "name", conn.IdentityData().DisplayName)
 			s.ReadPackets(ctx)
+			srv.RemoveSession(s)
 			srv.Log.Info("player disconnected", "name", conn.IdentityData().DisplayName)
 		}()
 	}

--- a/gobds/infra/misc.go
+++ b/gobds/infra/misc.go
@@ -10,7 +10,19 @@ type PingIndicator struct {
 	Identifier string
 }
 
-// AFKTimer represents session afk timer.
+// AFKTimer represents session afk timer configuration.
+//
+// TimeoutDuration is the idle duration after which a player becomes eligible
+// to be kicked for being AFK. The kick itself only fires when the server is at
+// least FullnessThreshold full.
+//
+// WarnApproaching and MarkAFK drive always-on soft warnings regardless of
+// server fullness. FinalWarning is only sent when the server is at or above
+// FullnessThreshold.
 type AFKTimer struct {
-	TimeoutDuration time.Duration
+	TimeoutDuration   time.Duration
+	WarnApproaching   time.Duration
+	MarkAFK           time.Duration
+	FinalWarning      time.Duration
+	FullnessThreshold float64
 }

--- a/gobds/server.go
+++ b/gobds/server.go
@@ -3,6 +3,7 @@ package gobds
 import (
 	"context"
 	"log/slog"
+	"sync"
 	"time"
 
 	"github.com/sandertv/gophertunnel/minecraft"
@@ -40,7 +41,35 @@ type Server struct {
 	ListenerFunc       ListenerFunc
 	DialerFunc         DialerFunc
 
+	// sessions holds every live *session.Session on this server, keyed by
+	// pointer so late-registering sessions with duplicate XUIDs (e.g. a
+	// reconnect racing with an old connection) don't clobber one another.
+	sessions sync.Map
+
 	Log *slog.Logger
+}
+
+// AddSession registers a session with the server for later iteration by the
+// AFK evaluator and any other per-server walkers.
+func (s *Server) AddSession(sess *session.Session) {
+	s.sessions.Store(sess, struct{}{})
+}
+
+// RemoveSession deregisters a session from the server.
+func (s *Server) RemoveSession(sess *session.Session) {
+	s.sessions.Delete(sess)
+}
+
+// Sessions returns a snapshot of the server's live sessions.
+func (s *Server) Sessions() []*session.Session {
+	var out []*session.Session
+	s.sessions.Range(func(k, _ any) bool {
+		if sess, ok := k.(*session.Session); ok {
+			out = append(out, sess)
+		}
+		return true
+	})
+	return out
 }
 
 // ListenerFunc creates a Listener.

--- a/gobds/session/config.go
+++ b/gobds/session/config.go
@@ -3,6 +3,7 @@ package session
 
 import (
 	"log/slog"
+	"time"
 
 	"github.com/smell-of-curry/gobds/gobds/claim"
 	"github.com/smell-of-curry/gobds/gobds/entity"
@@ -43,6 +44,7 @@ func (c Config) New() *Session {
 		data: NewData(c.Client),
 		log:  c.Log,
 	}
+	s.afk.lastMoveTime = time.Now()
 	s.registerHandlers()
 	return s
 }

--- a/gobds/session/handler_player_auth_input.go
+++ b/gobds/session/handler_player_auth_input.go
@@ -2,29 +2,18 @@ package session
 
 import (
 	"slices"
-	"time"
 
-	"github.com/go-gl/mathgl/mgl32"
 	"github.com/sandertv/gophertunnel/minecraft/protocol"
 	"github.com/sandertv/gophertunnel/minecraft/protocol/packet"
-	"github.com/sandertv/gophertunnel/minecraft/text"
 )
 
-// PlayerAuthInputHandler ...
-type PlayerAuthInputHandler struct {
-	lastMoveTime       time.Time
-	lastPosition       mgl32.Vec3
-	lastYaw, lastPitch float32
-}
+// PlayerAuthInputHandler handles PlayerAuthInput packets. AFK state lives on
+// the Session; this handler only feeds movement updates into it.
+type PlayerAuthInputHandler struct{}
 
 // NewPlayerAuthInputHandler ...
 func NewPlayerAuthInputHandler() *PlayerAuthInputHandler {
-	return &PlayerAuthInputHandler{
-		lastMoveTime: time.Now(),
-		lastPosition: mgl32.Vec3{},
-		lastYaw:      0,
-		lastPitch:    0,
-	}
+	return &PlayerAuthInputHandler{}
 }
 
 // Handle ...
@@ -33,37 +22,13 @@ func (h *PlayerAuthInputHandler) Handle(s *Session, pk packet.Packet, ctx *Conte
 
 	if pkt.Tick%20 == 0 {
 		s.SendPingIndicator()
-		h.handleAFKTimer(s, pkt, ctx)
-		if ctx.Cancelled() {
-			return nil
+		if s.afkTimer != nil {
+			s.TouchMovement(pkt.Position, pkt.Yaw, pkt.Pitch)
 		}
 	}
 
 	h.handleWorldBorder(s, pkt, ctx)
 	return nil
-}
-
-// handleAFKTimer ...
-func (h *PlayerAuthInputHandler) handleAFKTimer(s *Session, pkt *packet.PlayerAuthInput, ctx *Context) {
-	if s.afkTimer == nil {
-		return
-	}
-
-	moved := !h.lastPosition.ApproxEqual(pkt.Position) ||
-		!mgl32.FloatEqual(h.lastYaw, pkt.Yaw) ||
-		!mgl32.FloatEqual(h.lastPitch, pkt.Pitch)
-	if moved {
-		h.lastMoveTime = time.Now()
-		h.lastPosition = pkt.Position
-		h.lastYaw = pkt.Yaw
-		h.lastPitch = pkt.Pitch
-		return
-	}
-
-	if time.Since(h.lastMoveTime) > s.afkTimer.TimeoutDuration {
-		s.Disconnect(text.Colourf("<red>You've been kicked for being AFK.</red>"))
-		ctx.Cancel()
-	}
 }
 
 // handleWorldBorder ...

--- a/gobds/session/session.go
+++ b/gobds/session/session.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 	"log/slog"
 	"sync"
+	"time"
 
 	"github.com/df-mc/dragonfly/server/event"
 	"github.com/df-mc/dragonfly/server/session"
+	"github.com/go-gl/mathgl/mgl32"
 	"github.com/sandertv/gophertunnel/minecraft"
 	"github.com/sandertv/gophertunnel/minecraft/protocol/login"
 	"github.com/sandertv/gophertunnel/minecraft/protocol/packet"
@@ -33,8 +35,116 @@ type Session struct {
 
 	close chan struct{}
 
+	afk afkState
+
 	data *Data
 	log  *slog.Logger
+}
+
+// afkState tracks per-session AFK bookkeeping used by the AFK evaluator.
+//
+// The last position/rotation are stored here so the packet handler can be a
+// pure movement tracker without holding private state that the evaluator
+// goroutine cannot read.
+type afkState struct {
+	mu sync.RWMutex
+
+	lastMoveTime time.Time
+	lastPosition mgl32.Vec3
+	lastYaw      float32
+	lastPitch    float32
+
+	warnedApproaching bool
+	markedAFK         bool
+	warnedFinal       bool
+}
+
+// AFKTimer returns the session's AFK configuration, or nil if disabled.
+func (s *Session) AFKTimer() *infra.AFKTimer {
+	return s.afkTimer
+}
+
+// TouchMovement updates the last movement bookkeeping for the session. When
+// the position or orientation has changed it also resets the AFK warning
+// flags so the next idle streak starts from scratch. Returns true if the
+// session was considered to have moved.
+func (s *Session) TouchMovement(pos mgl32.Vec3, yaw, pitch float32) bool {
+	s.afk.mu.Lock()
+	defer s.afk.mu.Unlock()
+
+	moved := !s.afk.lastPosition.ApproxEqual(pos) ||
+		!mgl32.FloatEqual(s.afk.lastYaw, yaw) ||
+		!mgl32.FloatEqual(s.afk.lastPitch, pitch)
+	if !moved {
+		return false
+	}
+
+	s.afk.lastMoveTime = time.Now()
+	s.afk.lastPosition = pos
+	s.afk.lastYaw = yaw
+	s.afk.lastPitch = pitch
+	s.afk.warnedApproaching = false
+	s.afk.markedAFK = false
+	s.afk.warnedFinal = false
+	return true
+}
+
+// AFKDuration returns how long the session has been idle. Before the first
+// movement packet is received the session is considered to have just started
+// so the duration is measured from session creation.
+func (s *Session) AFKDuration() time.Duration {
+	s.afk.mu.RLock()
+	defer s.afk.mu.RUnlock()
+
+	if s.afk.lastMoveTime.IsZero() {
+		return 0
+	}
+	return time.Since(s.afk.lastMoveTime)
+}
+
+// WarnedApproaching returns whether the approaching-AFK soft warning has
+// already been sent for the current idle streak.
+func (s *Session) WarnedApproaching() bool {
+	s.afk.mu.RLock()
+	defer s.afk.mu.RUnlock()
+	return s.afk.warnedApproaching
+}
+
+// SetWarnedApproaching marks the approaching-AFK soft warning as sent.
+func (s *Session) SetWarnedApproaching(v bool) {
+	s.afk.mu.Lock()
+	s.afk.warnedApproaching = v
+	s.afk.mu.Unlock()
+}
+
+// MarkedAFK returns whether the "you are now AFK" soft warning has already
+// been sent for the current idle streak.
+func (s *Session) MarkedAFK() bool {
+	s.afk.mu.RLock()
+	defer s.afk.mu.RUnlock()
+	return s.afk.markedAFK
+}
+
+// SetMarkedAFK marks the "you are now AFK" soft warning as sent.
+func (s *Session) SetMarkedAFK(v bool) {
+	s.afk.mu.Lock()
+	s.afk.markedAFK = v
+	s.afk.mu.Unlock()
+}
+
+// WarnedFinal returns whether the near-capacity final warning has already
+// been sent for the current idle streak.
+func (s *Session) WarnedFinal() bool {
+	s.afk.mu.RLock()
+	defer s.afk.mu.RUnlock()
+	return s.afk.warnedFinal
+}
+
+// SetWarnedFinal marks the near-capacity final warning as sent.
+func (s *Session) SetWarnedFinal(v bool) {
+	s.afk.mu.Lock()
+	s.afk.warnedFinal = v
+	s.afk.mu.Unlock()
 }
 
 // SendPingIndicator ...

--- a/gobds/user_config.go
+++ b/gobds/user_config.go
@@ -51,6 +51,18 @@ type UserConfig struct {
 	AFKTimer struct {
 		Enabled         bool
 		TimeoutDuration string
+		// WarnApproaching is how long a player must be idle before receiving
+		// an "AFK in 1 minute" soft warning. Always sent regardless of fullness.
+		WarnApproaching string
+		// MarkAFK is how long a player must be idle before being told they
+		// are now AFK. Always sent regardless of fullness.
+		MarkAFK string
+		// FinalWarning is how long a player must be idle before receiving the
+		// near-capacity hard warning. Only sent when fullness >= FullnessThreshold.
+		FinalWarning string
+		// FullnessThreshold is the fraction (0..1) of MaxPlayers at or above
+		// which the proxy will start kicking AFK players, longest-AFK first.
+		FullnessThreshold float64
 	}
 	Resources struct {
 		PacksRequired bool
@@ -149,12 +161,34 @@ func (c UserConfig) afkTimer() *infra.AFKTimer {
 	if !c.AFKTimer.Enabled {
 		return nil
 	}
-	d, err := time.ParseDuration(c.AFKTimer.TimeoutDuration)
-	if err != nil {
-		// Fallback to a sensible default to avoid crash on invalid config
-		d = 10 * time.Minute
+	parse := func(s string, fallback time.Duration) time.Duration {
+		if s == "" {
+			return fallback
+		}
+		d, err := time.ParseDuration(s)
+		if err != nil {
+			return fallback
+		}
+		return d
 	}
-	return &infra.AFKTimer{TimeoutDuration: d}
+
+	timeout := parse(c.AFKTimer.TimeoutDuration, 10*time.Minute)
+	warn := parse(c.AFKTimer.WarnApproaching, 4*time.Minute)
+	mark := parse(c.AFKTimer.MarkAFK, 5*time.Minute)
+	final := parse(c.AFKTimer.FinalWarning, 9*time.Minute)
+
+	threshold := c.AFKTimer.FullnessThreshold
+	if threshold <= 0 || threshold > 1 {
+		threshold = 0.9
+	}
+
+	return &infra.AFKTimer{
+		TimeoutDuration:   timeout,
+		WarnApproaching:   warn,
+		MarkAFK:           mark,
+		FinalWarning:      final,
+		FullnessThreshold: threshold,
+	}
 }
 
 // pingIndicator returns new PingIndicator instance.
@@ -255,6 +289,10 @@ func DefaultConfig() UserConfig {
 
 	c.AFKTimer.Enabled = true
 	c.AFKTimer.TimeoutDuration = "10m"
+	c.AFKTimer.WarnApproaching = "4m"
+	c.AFKTimer.MarkAFK = "5m"
+	c.AFKTimer.FinalWarning = "9m"
+	c.AFKTimer.FullnessThreshold = 0.9
 
 	c.Resources.PacksRequired = false
 	c.Resources.CommandPath = "resources/commands.json"


### PR DESCRIPTION
Introduce a full AFK subsystem: add an AFK evaluator goroutine (gobds/afk.go) that issues soft warnings and kicks longest-AFK players when server fullness exceeds a configured threshold. Track per-session AFK state in Session (session/session.go) with thread-safe accessors (AFKDuration, TouchMovement, warning flags). Start/stop sessions are now registered on Server via AddSession/RemoveSession and enumerated with Sessions (server.go) for evaluator use. Move movement tracking out of the packet handler (session/handler_player_auth_input.go) to call TouchMovement on ticks. Initialize AFK last-move time on session creation (session/config.go). Extend infra.AFKTimer (infra/misc.go) and UserConfig to expose multiple warning timings and fullness threshold, add parsing with sensible defaults and default values (gobds/user_config.go). Also wire the evaluator startup in gobds.listen and ensure sessions are added/removed around connection handling.