### PR TITLE
Add claim proxy, traffic protection, session fixes

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,6 +20,8 @@ jobs:
         with:
           go-version: '1.26.0'
           cache: false
+      - name: Test
+        run: go test -race ./...
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@
 
 *.toml
 *.json
+!policy/*.json
 *.lock
 *.exe

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+# AGENTS.md
+
+## Learned User Preferences
+
+- Prefer gobds packet-level block/stall (claims, pickups, other hot actions) so work never reaches BDS Script API; extend claim proxy rather than adding BEH hot-path handlers for the same denial.
+- Open PR review threads: fix the issue or reply why intentional, then resolve — do not leave a pile of unanswered CodeRabbit/review comments.
+
+## Learned Workspace Facts
+
+- Claim proxy loads policy from `policy/claim_policy.v1.json` and can deny claim-related actions before they hit BDS; floor-only Y deny is intentional (not a bug).
+- Traffic/metrics keys may use raw XUID as the ops identifier; do not "fix" that to a hashed form without an explicit product decision.
+- bds-manager can build this repo from local source (`D:\bedrock-server\gobds`) into `bds-manager/gobds/gobds.exe` for the TESTING/Windows flow.

--- a/config.example.toml
+++ b/config.example.toml
@@ -36,6 +36,12 @@ MaxX = 12000 # The maximum X coordinate for the world border
 MinZ = -12000 # The minimum Z coordinate for the world border
 MaxZ = 12000 # The maximum Z coordinate for the world border
 
+[Claims]
+PrefilterEnabled = false # Whether to prefilter supported denied claim actions
+DenyRenderingEnabled = false # Whether to render deny blocks under protected claims
+PollInterval = '15s' # How often each server refreshes its immutable claim snapshot
+MaxSnapshotAge = '45s' # Older snapshots fail open and pass actions to BDS
+
 [PingIndicator]
 Enabled = true # Whether to enable the ping indicator
 Identifier = '&_playerPing:' # The identifier for the ping indicator
@@ -59,6 +65,40 @@ Key = 'secret-key' # The authentication key for the queues API
 Enabled = false # Whether this service is enabled
 URL = 'http://ip-api.com/json' # A service to validate users if they are using VPN's
 Key = '' # Authentication key if required
+
+[TrafficProtection]
+Enforce = false # Observe and count excess traffic by default; true drops rate excess.
+MaxTextBytes = 4096
+MaxCommandBytes = 4096
+MaxFormResponseBytes = 65536
+MaxFormResponseValues = 128
+MaxInventoryActions = 128
+MaxStackRequests = 64
+MaxStackActions = 128
+MaxTotalStackActions = 256
+
+[TrafficProtection.Chat]
+Rate = 8
+Burst = 16
+
+[TrafficProtection.Commands]
+Rate = 4
+Burst = 8
+
+[TrafficProtection.ModalFormResponses]
+Rate = 10
+Burst = 20
+
+[TrafficProtection.InventoryTransactions]
+Rate = 60
+Burst = 120
+
+[TrafficProtection.ItemStackRequests]
+Rate = 40
+Burst = 80
+
+[DuplicateXUID]
+Enabled = false # Reject simultaneous sessions for same non-empty XUID.
 
 [Encryption]
 Key = 'secret-key' # The Encryption key used for XUID messages to BDS

--- a/gobds/block/deny.go
+++ b/gobds/block/deny.go
@@ -1,0 +1,29 @@
+package block
+
+import (
+	"github.com/df-mc/dragonfly/server/block/model"
+	"github.com/df-mc/dragonfly/server/world"
+)
+
+// Deny ...
+type Deny struct{}
+
+// EncodeItem ...
+func (Deny) EncodeItem() (name string, meta int16) {
+	return "minecraft:deny", 0
+}
+
+// EncodeBlock ...
+func (Deny) EncodeBlock() (string, map[string]any) {
+	return "minecraft:deny", nil
+}
+
+// Model ...
+func (Deny) Model() world.BlockModel {
+	return model.Solid{}
+}
+
+// Hash ...
+func (Deny) Hash() (uint64, uint64) {
+	return hashDeny, 0
+}

--- a/gobds/block/factory.go
+++ b/gobds/block/factory.go
@@ -6,4 +6,5 @@ func init() {
 	for _, b := range Buttons() {
 		world.RegisterBlock(b)
 	}
+	world.RegisterBlock(Deny{})
 }

--- a/gobds/block/hash.go
+++ b/gobds/block/hash.go
@@ -4,4 +4,5 @@ import "github.com/df-mc/dragonfly/server/block"
 
 var (
 	hashButton = block.NextHash()
+	hashDeny   = block.NextHash()
 )

--- a/gobds/claim/factory.go
+++ b/gobds/claim/factory.go
@@ -2,43 +2,80 @@
 package claim
 
 import (
+	"fmt"
 	"log/slog"
-	"maps"
 	"sync"
+	"sync/atomic"
+	"time"
 
 	"github.com/smell-of-curry/gobds/gobds/service"
 )
 
+const (
+	// DefaultPollInterval controls claim refresh frequency.
+	DefaultPollInterval = 15 * time.Second
+	// DefaultMaxSnapshotAge is maximum age at which proxy denials are safe.
+	DefaultMaxSnapshotAge = 45 * time.Second
+)
+
 // Factory ...
 type Factory struct {
-	service *Service
-	data    map[string]PlayerClaim
-
-	mu  sync.RWMutex
-	log *slog.Logger
+	service        *Service
+	refreshMu      sync.Mutex
+	snapshot       atomic.Pointer[Snapshot]
+	generation     atomic.Uint64
+	failureStatus  atomic.Uint32
+	pollInterval   time.Duration
+	maxSnapshotAge time.Duration
+	metrics        *Metrics
+	log            *slog.Logger
 }
 
 // NewFactory ...
-func NewFactory(c service.Config, log *slog.Logger) *Factory {
+func NewFactory(
+	c service.Config,
+	server string,
+	pollInterval, maxSnapshotAge time.Duration,
+	log *slog.Logger,
+) *Factory {
 	return &Factory{
-		service: NewService(c, log),
-		data:    make(map[string]PlayerClaim),
-		log:     log,
+		service:        NewService(c, log),
+		pollInterval:   pollInterval,
+		maxSnapshotAge: maxSnapshotAge,
+		metrics:        NewMetrics(server),
+		log:            log,
 	}
 }
 
-// All ...
-func (f *Factory) All() map[string]PlayerClaim {
-	f.mu.RLock()
-	defer f.mu.RUnlock()
-	return maps.Clone(f.data)
+// PollInterval returns configured refresh frequency.
+func (f *Factory) PollInterval() time.Duration {
+	return f.pollInterval
 }
 
-// Set ...
-func (f *Factory) Set(claims map[string]PlayerClaim) {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	f.data = claims
+// Metrics returns this server's claim proxy metrics.
+func (f *Factory) Metrics() *Metrics {
+	return f.metrics
+}
+
+// Snapshot returns current immutable snapshot and fail-open status.
+func (f *Factory) Snapshot(now time.Time) (*Snapshot, QueryStatus) {
+	snapshot := f.snapshot.Load()
+	if snapshot == nil {
+		if status := QueryStatus(f.failureStatus.Load()); status != QueryReady {
+			return nil, status
+		}
+		return nil, QueryMissing
+	}
+	if !snapshot.Supported() {
+		return snapshot, QueryUnsupported
+	}
+	if snapshot.Age(now) > f.maxSnapshotAge {
+		if status := QueryStatus(f.failureStatus.Load()); status != QueryReady {
+			return snapshot, status
+		}
+		return snapshot, QueryStale
+	}
+	return snapshot, QueryReady
 }
 
 // Fetch ...
@@ -46,12 +83,40 @@ func (f *Factory) Fetch() error {
 	if f.service == nil || !f.service.Enabled {
 		return nil
 	}
+	f.refreshMu.Lock()
+	defer f.refreshMu.Unlock()
+	f.metrics.RefreshAttempt()
 
-	claims, err := f.service.FetchClaims()
+	result, err := f.service.FetchClaims()
 	if err != nil {
+		f.failureStatus.Store(uint32(QueryRefreshFailed))
+		f.metrics.RefreshFailure()
 		return err
 	}
-
-	f.Set(claims)
+	now := time.Now()
+	if result.NotModified {
+		current := f.snapshot.Load()
+		if current == nil {
+			f.failureStatus.Store(uint32(QueryRefreshFailed))
+			f.metrics.RefreshFailure()
+			return fmt.Errorf("claims service returned 304 without a snapshot")
+		}
+		revalidated := *current
+		revalidated.Generation = f.generation.Add(1)
+		revalidated.FetchedAt = now
+		f.snapshot.Store(&revalidated)
+		f.failureStatus.Store(uint32(QueryReady))
+		f.metrics.RefreshSuccess()
+		return nil
+	}
+	next, err := BuildSnapshot(result.Claims, f.generation.Add(1), now)
+	if err != nil {
+		f.failureStatus.Store(uint32(QueryInvalid))
+		f.metrics.RefreshFailure()
+		return fmt.Errorf("build claim snapshot: %w", err)
+	}
+	f.snapshot.Store(next)
+	f.failureStatus.Store(uint32(QueryReady))
+	f.metrics.RefreshSuccess()
 	return nil
 }

--- a/gobds/claim/factory_test.go
+++ b/gobds/claim/factory_test.go
@@ -1,0 +1,80 @@
+package claim
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/smell-of-curry/gobds/gobds/service"
+)
+
+func TestFactoryFreshnessFailsOpenAfterMaximumAge(t *testing.T) {
+	factory := NewFactory(service.Config{}, "test", time.Second, 3*time.Second, slog.Default())
+	now := time.Unix(100, 0)
+	snapshot, err := BuildSnapshot(map[string]PlayerClaim{
+		"one": testSnapshotClaim("one", 0, 15),
+	}, 1, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	factory.snapshot.Store(snapshot)
+
+	if _, status := factory.Snapshot(now.Add(3 * time.Second)); status != QueryReady {
+		t.Fatalf("snapshot at max age should remain ready, got %v", status)
+	}
+	if _, status := factory.Snapshot(now.Add(3*time.Second + time.Nanosecond)); status != QueryStale {
+		t.Fatalf("old snapshot should fail open as stale, got %v", status)
+	}
+	factory.failureStatus.Store(uint32(QueryRefreshFailed))
+	if _, status := factory.Snapshot(now.Add(4 * time.Second)); status != QueryRefreshFailed {
+		t.Fatalf("failed refresh beyond max age should be explicit, got %v", status)
+	}
+}
+
+func TestFactoryKeepsPreviousSnapshotWhenReplacementInvalid(t *testing.T) {
+	valid := true
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		if valid {
+			_, _ = writer.Write([]byte(`[{"_key":"one","data":{"claimId":"one","playerXUID":"owner","location":{"dimension":"minecraft:overworld","pos1":{"x":0,"z":0},"pos2":{"x":1,"z":1}}}}]`))
+			return
+		}
+		_, _ = writer.Write([]byte(`[{"_key":"bad","data":{"claimId":"bad","playerXUID":"owner","location":{"dimension":"invalid","pos1":{"x":0,"z":0},"pos2":{"x":1,"z":1}}}}]`))
+	}))
+	defer server.Close()
+
+	factory := NewFactory(
+		service.Config{Enabled: true, URL: server.URL},
+		"test",
+		time.Second,
+		time.Minute,
+		slog.Default(),
+	)
+	if err := factory.Fetch(); err != nil {
+		t.Fatal(err)
+	}
+	previous, status := factory.Snapshot(time.Now())
+	if status != QueryReady {
+		t.Fatalf("initial status = %v", status)
+	}
+	valid = false
+	if err := factory.Fetch(); err == nil {
+		t.Fatal("invalid replacement must fail")
+	}
+	current, status := factory.Snapshot(time.Now())
+	if status != QueryReady || current != previous {
+		t.Fatal("fresh previous snapshot must survive invalid replacement without partial swap")
+	}
+}
+
+func TestFactoryMissingAndUnsupportedSnapshotsFailOpen(t *testing.T) {
+	factory := NewFactory(service.Config{}, "test", time.Second, 3*time.Second, slog.Default())
+	if _, status := factory.Snapshot(time.Now()); status != QueryMissing {
+		t.Fatalf("missing snapshot status = %v", status)
+	}
+	factory.snapshot.Store(&Snapshot{PolicyVersion: PolicyVersion + 1, FetchedAt: time.Now()})
+	if _, status := factory.Snapshot(time.Now()); status != QueryUnsupported {
+		t.Fatalf("unsupported snapshot status = %v", status)
+	}
+}

--- a/gobds/claim/metrics.go
+++ b/gobds/claim/metrics.go
@@ -1,0 +1,189 @@
+package claim
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"sync/atomic"
+	"time"
+)
+
+const (
+	metricActions  = 9
+	metricReasons  = 8
+	latencyBuckets = 5
+)
+
+var (
+	actionMetricNames = [metricActions]string{
+		"render", "block_break", "block_place", "block_interact", "entity_interact",
+		"entity_hurt", "item_release", "item_throw", "item_drop",
+	}
+	reasonMetricNames = [metricReasons]string{
+		"ready", "missing", "stale", "unsupported", "unknown_dimension", "invalid",
+		"overlap", "refresh_failed",
+	}
+)
+
+// Metrics contains per-server dependency-free atomic claim proxy counters.
+type Metrics struct {
+	server string
+
+	refreshAttempts atomic.Uint64
+	refreshSuccess  atomic.Uint64
+	refreshFailure  atomic.Uint64
+	packets         atomic.Uint64
+	seen            [metricActions]atomic.Uint64
+	forwarded       [metricActions]atomic.Uint64
+	denied          [metricActions]atomic.Uint64
+	reasons         [metricReasons]atomic.Uint64
+	candidates      atomic.Uint64
+	latency         [latencyBuckets]atomic.Uint64
+	correctionsSent atomic.Uint64
+	correctionsSkip atomic.Uint64
+	subchunkDecode  atomic.Uint64
+	subchunkModify  atomic.Uint64
+	subchunkError   atomic.Uint64
+}
+
+// NewMetrics creates metrics isolated to one configured server.
+func NewMetrics(server string) *Metrics {
+	return &Metrics{server: server}
+}
+
+func (m *Metrics) RefreshAttempt() { m.refreshAttempts.Add(1) }
+func (m *Metrics) RefreshSuccess() { m.refreshSuccess.Add(1) }
+func (m *Metrics) RefreshFailure() { m.refreshFailure.Add(1) }
+func (m *Metrics) Packet()         { m.packets.Add(1) }
+
+// Action records one policy decision by fixed action index.
+func (m *Metrics) Action(action uint8, forwarded bool) {
+	if m == nil || int(action) >= metricActions {
+		return
+	}
+	m.seen[action].Add(1)
+	if forwarded {
+		m.forwarded[action].Add(1)
+		return
+	}
+	m.denied[action].Add(1)
+}
+
+// Reason records a fail-open reason by fixed reason index.
+func (m *Metrics) Reason(reason QueryStatus) {
+	if m == nil || int(reason) >= metricReasons {
+		return
+	}
+	m.reasons[reason].Add(1)
+}
+
+// Candidates records number of spatial candidates examined.
+func (m *Metrics) Candidates(count int) {
+	if m != nil {
+		m.candidates.Add(uint64(max(count, 0)))
+	}
+}
+
+// Latency records handler latency in fixed <=10µs, <=50µs, <=250µs, <=1ms, >1ms buckets.
+func (m *Metrics) Latency(elapsed time.Duration) {
+	if m == nil {
+		return
+	}
+	index := 4
+	switch {
+	case elapsed <= 10*time.Microsecond:
+		index = 0
+	case elapsed <= 50*time.Microsecond:
+		index = 1
+	case elapsed <= 250*time.Microsecond:
+		index = 2
+	case elapsed <= time.Millisecond:
+		index = 3
+	}
+	m.latency[index].Add(1)
+}
+
+func (m *Metrics) Correction(sent bool) {
+	if sent {
+		m.correctionsSent.Add(1)
+		return
+	}
+	m.correctionsSkip.Add(1)
+}
+
+func (m *Metrics) SubchunkDecoded()  { m.subchunkDecode.Add(1) }
+func (m *Metrics) SubchunkModified() { m.subchunkModify.Add(1) }
+func (m *Metrics) SubchunkError()    { m.subchunkError.Add(1) }
+
+type metricRecord struct {
+	Type        string                 `json:"type"`
+	Server      string                 `json:"server"`
+	PeriodMS    int64                  `json:"period_ms"`
+	ActionNames [metricActions]string  `json:"action_names"`
+	ReasonNames [metricReasons]string  `json:"reason_names"`
+	Refresh     [3]uint64              `json:"refresh"`
+	Snapshot    snapshotMetric         `json:"snapshot"`
+	Packets     uint64                 `json:"packets"`
+	Seen        [metricActions]uint64  `json:"seen"`
+	Forwarded   [metricActions]uint64  `json:"forwarded"`
+	Denied      [metricActions]uint64  `json:"denied"`
+	Reasons     [metricReasons]uint64  `json:"reasons"`
+	Candidates  uint64                 `json:"candidates"`
+	Latency     [latencyBuckets]uint64 `json:"latency_us"`
+	Corrections [2]uint64              `json:"corrections"`
+	Subchunk    [3]uint64              `json:"subchunk"`
+}
+
+type snapshotMetric struct {
+	AgeMS      int64  `json:"age_ms"`
+	Generation uint64 `json:"generation"`
+	Claims     int    `json:"claims"`
+	Cells      int    `json:"cells"`
+}
+
+// WriteDelta emits one compact JSON record and resets interval counters.
+func (m *Metrics) WriteDelta(output io.Writer, period time.Duration, snapshot *Snapshot) {
+	if m == nil {
+		return
+	}
+	record := metricRecord{
+		Type:        "claim_proxy_metrics",
+		Server:      m.server,
+		PeriodMS:    period.Milliseconds(),
+		ActionNames: actionMetricNames,
+		ReasonNames: reasonMetricNames,
+		Packets:     m.packets.Swap(0),
+		Refresh: [3]uint64{
+			m.refreshAttempts.Swap(0),
+			m.refreshSuccess.Swap(0),
+			m.refreshFailure.Swap(0),
+		},
+		Candidates:  m.candidates.Swap(0),
+		Corrections: [2]uint64{m.correctionsSent.Swap(0), m.correctionsSkip.Swap(0)},
+		Subchunk:    [3]uint64{m.subchunkDecode.Swap(0), m.subchunkModify.Swap(0), m.subchunkError.Swap(0)},
+		Snapshot:    snapshotMetric{AgeMS: -1},
+	}
+	for i := range metricActions {
+		record.Seen[i] = m.seen[i].Swap(0)
+		record.Forwarded[i] = m.forwarded[i].Swap(0)
+		record.Denied[i] = m.denied[i].Swap(0)
+	}
+	for i := range metricReasons {
+		record.Reasons[i] = m.reasons[i].Swap(0)
+	}
+	for i := range latencyBuckets {
+		record.Latency[i] = m.latency[i].Swap(0)
+	}
+	if snapshot != nil {
+		record.Snapshot = snapshotMetric{
+			AgeMS:      snapshot.Age(time.Now()).Milliseconds(),
+			Generation: snapshot.Generation,
+			Claims:     snapshot.ClaimCount,
+			Cells:      snapshot.CellCount,
+		}
+	}
+	raw, err := json.Marshal(record)
+	if err == nil {
+		_, _ = fmt.Fprintln(output, string(raw))
+	}
+}

--- a/gobds/claim/metrics.go
+++ b/gobds/claim/metrics.go
@@ -51,10 +51,17 @@ func NewMetrics(server string) *Metrics {
 	return &Metrics{server: server}
 }
 
+// RefreshAttempt records one claim-refresh attempt.
 func (m *Metrics) RefreshAttempt() { m.refreshAttempts.Add(1) }
+
+// RefreshSuccess records one successful claim refresh.
 func (m *Metrics) RefreshSuccess() { m.refreshSuccess.Add(1) }
+
+// RefreshFailure records one failed claim refresh.
 func (m *Metrics) RefreshFailure() { m.refreshFailure.Add(1) }
-func (m *Metrics) Packet()         { m.packets.Add(1) }
+
+// Packet records one processed claim-related packet.
+func (m *Metrics) Packet() { m.packets.Add(1) }
 
 // Action records one policy decision by fixed action index.
 func (m *Metrics) Action(action uint8, forwarded bool) {
@@ -103,6 +110,7 @@ func (m *Metrics) Latency(elapsed time.Duration) {
 	m.latency[index].Add(1)
 }
 
+// Correction records whether a corrective packet was sent or skipped.
 func (m *Metrics) Correction(sent bool) {
 	if sent {
 		m.correctionsSent.Add(1)
@@ -111,9 +119,14 @@ func (m *Metrics) Correction(sent bool) {
 	m.correctionsSkip.Add(1)
 }
 
-func (m *Metrics) SubchunkDecoded()  { m.subchunkDecode.Add(1) }
+// SubchunkDecoded records one successfully decoded subchunk payload.
+func (m *Metrics) SubchunkDecoded() { m.subchunkDecode.Add(1) }
+
+// SubchunkModified records one subchunk rewritten with deny blocks.
 func (m *Metrics) SubchunkModified() { m.subchunkModify.Add(1) }
-func (m *Metrics) SubchunkError()    { m.subchunkError.Add(1) }
+
+// SubchunkError records one subchunk decode or index failure.
+func (m *Metrics) SubchunkError() { m.subchunkError.Add(1) }
 
 type metricRecord struct {
 	Type        string                 `json:"type"`

--- a/gobds/claim/metrics_test.go
+++ b/gobds/claim/metrics_test.go
@@ -1,0 +1,50 @@
+package claim
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestMetricsEmitPerServerDeltaJSON(t *testing.T) {
+	var output bytes.Buffer
+	metrics := NewMetrics("GOLD")
+	metrics.RefreshAttempt()
+	metrics.RefreshSuccess()
+	metrics.Packet()
+	metrics.Action(1, false)
+	metrics.Reason(QueryOverlap)
+	metrics.Candidates(2)
+	metrics.Latency(20 * time.Microsecond)
+	metrics.Correction(true)
+	metrics.SubchunkDecoded()
+	metrics.SubchunkModified()
+
+	metrics.WriteDelta(&output, time.Minute, &Snapshot{
+		PolicyVersion: PolicyVersion,
+		SchemaVersion: SchemaVersion,
+		Generation:    4,
+		FetchedAt:     time.Now(),
+		ClaimCount:    3,
+		CellCount:     5,
+	})
+	var record metricRecord
+	if err := json.Unmarshal(output.Bytes(), &record); err != nil {
+		t.Fatal(err)
+	}
+	if record.Server != "GOLD" || record.Packets != 1 || record.Refresh != [3]uint64{1, 1, 0} ||
+		record.Seen[1] != 1 || record.Denied[1] != 1 || record.Reasons[QueryOverlap] != 1 ||
+		record.Snapshot.Generation != 4 {
+		t.Fatalf("unexpected metric record: %+v", record)
+	}
+
+	output.Reset()
+	metrics.WriteDelta(&output, time.Minute, nil)
+	if err := json.Unmarshal(output.Bytes(), &record); err != nil {
+		t.Fatal(err)
+	}
+	if record.Refresh != [3]uint64{} || record.Seen[1] != 0 {
+		t.Fatal("delta counters did not reset")
+	}
+}

--- a/gobds/claim/model.go
+++ b/gobds/claim/model.go
@@ -10,21 +10,54 @@ type ResponseModel struct {
 
 // PlayerClaim ...
 type PlayerClaim struct {
-	ID           string   `json:"claimId"`
-	OwnerXUID    string   `json:"playerXUID"`
-	Location     Location `json:"location"`
-	TrustedXUIDS []string `json:"trusts"`
+	ID           string    `json:"claimId"`
+	OwnerXUID    string    `json:"playerXUID"`
+	Location     Location  `json:"location"`
+	Features     []Feature `json:"features"`
+	TrustedXUIDS []string  `json:"trusts"`
 }
 
 // Location ...
 type Location struct {
 	Dimension string  `json:"dimension"`
-	Pos1      Vector2 `json:"pos2"`
-	Pos2      Vector2 `json:"pos1"`
+	Pos1      Vector2 `json:"pos1"`
+	Pos2      Vector2 `json:"pos2"`
+}
+
+const (
+	// FeatureTypeMineable ...
+	FeatureTypeMineable = "mineable"
+	// FeatureTypeBlockPlaceable ...
+	FeatureTypeBlockPlaceable = "blockPlaceable"
+	// FeatureTypeBlockInteractable preserves the API's historical "intractable" value.
+	FeatureTypeBlockInteractable = "blockIntractable"
+	// FeatureTypeEntityInteractable preserves the API's historical "intractable" value.
+	FeatureTypeEntityInteractable = "entityIntractable"
+	// FeatureTypeEntityHurt ...
+	FeatureTypeEntityHurt = "entityHurt"
+	// FeatureTypeDropItems ...
+	FeatureTypeDropItems = "dropItems"
+)
+
+// Feature ...
+type Feature struct {
+	Type          string   `json:"type"`
+	FromLocation  *Vector3 `json:"fromLocation,omitempty"`
+	ToLocation    *Vector3 `json:"toLocation,omitempty"`
+	BlockTypeIDs  []string `json:"blockTypeIds,omitempty"`
+	EntityTypeIDs []string `json:"entityTypeIds,omitempty"`
+	ItemTypeIDs   []string `json:"itemTypeIds,omitempty"`
 }
 
 // Vector2 ...
 type Vector2 struct {
 	X float32 `json:"x"`
+	Z float32 `json:"z"`
+}
+
+// Vector3 ...
+type Vector3 struct {
+	X float32 `json:"x"`
+	Y float32 `json:"y"`
 	Z float32 `json:"z"`
 }

--- a/gobds/claim/model_test.go
+++ b/gobds/claim/model_test.go
@@ -1,0 +1,23 @@
+package claim
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestPlayerClaimJSONMatchesBehaviorPackSchema(t *testing.T) {
+	var cl PlayerClaim
+	err := json.Unmarshal([]byte(`{
+		"location":{"dimension":"minecraft:overworld","pos1":{"x":1,"z":2},"pos2":{"x":3,"z":4}},
+		"features":[{"type":"blockIntractable","fromLocation":{"x":5,"y":6,"z":7}}]
+	}`), &cl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cl.Location.Pos1 != (Vector2{X: 1, Z: 2}) || cl.Location.Pos2 != (Vector2{X: 3, Z: 4}) {
+		t.Fatalf("unexpected claim bounds: %+v", cl.Location)
+	}
+	if len(cl.Features) != 1 || cl.Features[0].FromLocation == nil || cl.Features[0].ToLocation != nil {
+		t.Fatalf("unexpected feature bounds: %+v", cl.Features)
+	}
+}

--- a/gobds/claim/service.go
+++ b/gobds/claim/service.go
@@ -3,7 +3,6 @@ package claim
 import (
 	"context"
 	"fmt"
-	"io"
 	"log/slog"
 	"net/http"
 	"time"
@@ -15,6 +14,7 @@ import (
 // Service ...
 type Service struct {
 	*service.Service
+	lastModified string
 }
 
 // NewService ...
@@ -22,67 +22,92 @@ func NewService(c service.Config, log *slog.Logger) *Service {
 	return &Service{Service: service.NewService(log, c)}
 }
 
+// FetchResult contains claim rows plus HTTP revalidation state.
+type FetchResult struct {
+	Claims       map[string]PlayerClaim
+	NotModified  bool
+	LastModified string
+}
+
 // FetchClaims ...
-func (s *Service) FetchClaims() (map[string]PlayerClaim, error) {
+func (s *Service) FetchClaims() (FetchResult, error) {
 	if !s.Enabled {
-		return map[string]PlayerClaim{}, nil
+		return FetchResult{Claims: map[string]PlayerClaim{}}, nil
 	}
 	var lastErr error
 	for attempt := 0; attempt <= service.MaxRetries; attempt++ {
 		if s.Closed {
-			break
+			return FetchResult{}, fmt.Errorf("service closed")
 		}
 		if attempt > 0 {
 			time.Sleep(service.RetryDelay)
 		}
 
 		ctx, cancel := context.WithTimeout(context.Background(), service.RequestTimeout)
-		defer cancel()
 		request, err := http.NewRequestWithContext(ctx, http.MethodGet, s.URL, nil)
 		if err != nil {
-			return nil, fmt.Errorf("failed to create request: %w", err)
+			cancel()
+			return FetchResult{}, fmt.Errorf("failed to create request: %w", err)
 		}
 		request.Header.Set("authorization", s.Key)
+		if s.lastModified != "" {
+			request.Header.Set("if-modified-since", s.lastModified)
+		}
 
 		response, err := s.Client.Do(request)
 		if err != nil {
+			cancel()
 			lastErr = fmt.Errorf("request failed: %w", err)
 			if service.ErrorIsTemporary(err) {
 				continue
 			}
-			return nil, lastErr
+			return FetchResult{}, lastErr
 		}
-		defer func() { _ = response.Body.Close() }()
 
 		switch response.StatusCode {
 		case http.StatusOK:
-			body, err := io.ReadAll(response.Body)
-			if err != nil {
-				lastErr = fmt.Errorf("failed to read response body: %w", err)
-				continue
-			}
-
 			var claimResponse []ResponseModel
-			err = json.Unmarshal(body, &claimResponse)
-			if err != nil {
-				lastErr = fmt.Errorf("failed to unmarshal response body: %w", err)
+			if err = json.NewDecoder(response.Body).Decode(&claimResponse); err != nil {
+				_ = response.Body.Close()
+				cancel()
+				lastErr = fmt.Errorf("failed to decode response: %w", err)
 				continue
 			}
+			_ = response.Body.Close()
+			cancel()
 
-			s.Log.Info("fetched claims", "count", len(claimResponse))
-
-			obj := make(map[string]PlayerClaim)
+			obj := make(map[string]PlayerClaim, len(claimResponse))
 			for _, v := range claimResponse {
+				if _, exists := obj[v.Key]; exists {
+					return FetchResult{}, fmt.Errorf("duplicate claim response key %q", v.Key)
+				}
 				obj[v.Key] = v.Data
 			}
-			return obj, nil
+			s.lastModified = response.Header.Get("last-modified")
+			return FetchResult{
+				Claims:       obj,
+				LastModified: s.lastModified,
+			}, nil
+		case http.StatusNotModified:
+			if modified := response.Header.Get("last-modified"); modified != "" {
+				s.lastModified = modified
+			}
+			_ = response.Body.Close()
+			cancel()
+			return FetchResult{NotModified: true, LastModified: s.lastModified}, nil
 		case http.StatusTooManyRequests:
+			_ = response.Body.Close()
+			cancel()
 			lastErr = fmt.Errorf("rate limited")
-			time.Sleep(time.Duration(attempt+1) * service.RetryDelay)
 			continue
 		default:
+			_ = response.Body.Close()
+			cancel()
 			lastErr = fmt.Errorf("unexpected status code: %d", response.StatusCode)
 		}
 	}
-	return nil, lastErr
+	if lastErr == nil {
+		lastErr = fmt.Errorf("claims service unavailable")
+	}
+	return FetchResult{}, lastErr
 }

--- a/gobds/claim/service.go
+++ b/gobds/claim/service.go
@@ -64,50 +64,56 @@ func (s *Service) FetchClaims() (FetchResult, error) {
 			return FetchResult{}, lastErr
 		}
 
-		switch response.StatusCode {
-		case http.StatusOK:
-			var claimResponse []ResponseModel
-			if err = json.NewDecoder(response.Body).Decode(&claimResponse); err != nil {
-				_ = response.Body.Close()
-				cancel()
-				lastErr = fmt.Errorf("failed to decode response: %w", err)
-				continue
-			}
-			_ = response.Body.Close()
-			cancel()
-
-			obj := make(map[string]PlayerClaim, len(claimResponse))
-			for _, v := range claimResponse {
-				if _, exists := obj[v.Key]; exists {
-					return FetchResult{}, fmt.Errorf("duplicate claim response key %q", v.Key)
-				}
-				obj[v.Key] = v.Data
-			}
-			s.lastModified = response.Header.Get("last-modified")
-			return FetchResult{
-				Claims:       obj,
-				LastModified: s.lastModified,
-			}, nil
-		case http.StatusNotModified:
-			if modified := response.Header.Get("last-modified"); modified != "" {
-				s.lastModified = modified
-			}
-			_ = response.Body.Close()
-			cancel()
-			return FetchResult{NotModified: true, LastModified: s.lastModified}, nil
-		case http.StatusTooManyRequests:
-			_ = response.Body.Close()
-			cancel()
-			lastErr = fmt.Errorf("rate limited")
+		result, err, retry := s.handleFetchResponse(response, cancel)
+		if retry {
+			lastErr = err
 			continue
-		default:
-			_ = response.Body.Close()
-			cancel()
-			lastErr = fmt.Errorf("unexpected status code: %d", response.StatusCode)
 		}
+		if err != nil {
+			return FetchResult{}, err
+		}
+		return result, nil
 	}
 	if lastErr == nil {
 		lastErr = fmt.Errorf("claims service unavailable")
 	}
 	return FetchResult{}, lastErr
+}
+
+// handleFetchResponse closes the body, cancels the request context, and returns
+// (result, err, retry). retry=true means the caller should continue the loop.
+func (s *Service) handleFetchResponse(response *http.Response, cancel context.CancelFunc) (FetchResult, error, bool) {
+	defer cancel()
+	defer func() { _ = response.Body.Close() }()
+
+	switch response.StatusCode {
+	case http.StatusOK:
+		var claimResponse []ResponseModel
+		if err := json.NewDecoder(response.Body).Decode(&claimResponse); err != nil {
+			return FetchResult{}, fmt.Errorf("failed to decode response: %w", err), true
+		}
+		obj := make(map[string]PlayerClaim, len(claimResponse))
+		for _, v := range claimResponse {
+			if _, exists := obj[v.Key]; exists {
+				return FetchResult{}, fmt.Errorf("duplicate claim response key %q", v.Key), false
+			}
+			obj[v.Key] = v.Data
+		}
+		if modified := response.Header.Get("last-modified"); modified != "" {
+			s.lastModified = modified
+		}
+		return FetchResult{
+			Claims:       obj,
+			LastModified: s.lastModified,
+		}, nil, false
+	case http.StatusNotModified:
+		if modified := response.Header.Get("last-modified"); modified != "" {
+			s.lastModified = modified
+		}
+		return FetchResult{NotModified: true, LastModified: s.lastModified}, nil, false
+	case http.StatusTooManyRequests:
+		return FetchResult{}, fmt.Errorf("rate limited"), true
+	default:
+		return FetchResult{}, fmt.Errorf("unexpected status code: %d", response.StatusCode), true
+	}
 }

--- a/gobds/claim/service_test.go
+++ b/gobds/claim/service_test.go
@@ -1,0 +1,38 @@
+package claim
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/smell-of-curry/gobds/gobds/service"
+)
+
+func TestServiceUsesAdvertisedLastModifiedFor304(t *testing.T) {
+	const modified = "Tue, 14 Jul 2026 12:00:00 GMT"
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		requests++
+		if requests == 2 {
+			if got := request.Header.Get("if-modified-since"); got != modified {
+				t.Errorf("If-Modified-Since = %q", got)
+			}
+			writer.WriteHeader(http.StatusNotModified)
+			return
+		}
+		writer.Header().Set("Last-Modified", modified)
+		_, _ = writer.Write([]byte(`[{"_key":"one","data":{"claimId":"one","playerXUID":"owner","location":{"dimension":"minecraft:overworld","pos1":{"x":0,"z":0},"pos2":{"x":1,"z":1}}}}]`))
+	}))
+	defer server.Close()
+
+	client := NewService(service.Config{Enabled: true, URL: server.URL}, slog.Default())
+	first, err := client.FetchClaims()
+	if err != nil || len(first.Claims) != 1 || first.NotModified {
+		t.Fatalf("unexpected initial fetch: result=%+v err=%v", first, err)
+	}
+	second, err := client.FetchClaims()
+	if err != nil || !second.NotModified {
+		t.Fatalf("unexpected revalidation: result=%+v err=%v", second, err)
+	}
+}

--- a/gobds/claim/snapshot.go
+++ b/gobds/claim/snapshot.go
@@ -40,13 +40,21 @@ type cellKey struct {
 type QueryStatus uint8
 
 const (
+	// QueryReady means the snapshot can be used for policy decisions.
 	QueryReady QueryStatus = iota
+	// QueryMissing means no snapshot has been published yet.
 	QueryMissing
+	// QueryStale means the snapshot exceeded the configured max age.
 	QueryStale
+	// QueryUnsupported means policy/schema versions are not understood.
 	QueryUnsupported
+	// QueryUnknownDimension means the packet dimension could not be mapped.
 	QueryUnknownDimension
+	// QueryInvalid means the query inputs were malformed.
 	QueryInvalid
+	// QueryOverlap means multiple claims matched the same position.
 	QueryOverlap
+	// QueryRefreshFailed means the last refresh attempt failed.
 	QueryRefreshFailed
 )
 

--- a/gobds/claim/snapshot.go
+++ b/gobds/claim/snapshot.go
@@ -1,0 +1,239 @@
+package claim
+
+import (
+	"fmt"
+	"math"
+	"strings"
+	"time"
+)
+
+const (
+	// PolicyVersion identifies claim decision semantics shared with BEH.
+	PolicyVersion = 1
+	// SchemaVersion identifies claim payload shape shared with BEH.
+	SchemaVersion = 1
+	cellSize      = 16
+	// ponytail: 262k-cell ceiling bounds hostile payload cost; add coarse cells if world claims exceed it.
+	maxCellsPerClaim = 1 << 18
+)
+
+// Snapshot is immutable after construction and safe for concurrent lock-free reads.
+type Snapshot struct {
+	PolicyVersion int
+	SchemaVersion int
+	Generation    uint64
+	GeneratedAt   time.Time
+	FetchedAt     time.Time
+	ClaimCount    int
+	CellCount     int
+
+	claims []PlayerClaim
+	cells  map[string]map[cellKey][]*PlayerClaim
+}
+
+type cellKey struct {
+	x int32
+	z int32
+}
+
+// QueryStatus explains whether proxy policy can safely act on a query.
+type QueryStatus uint8
+
+const (
+	QueryReady QueryStatus = iota
+	QueryMissing
+	QueryStale
+	QueryUnsupported
+	QueryUnknownDimension
+	QueryInvalid
+	QueryOverlap
+	QueryRefreshFailed
+)
+
+// Candidates returns immutable claims from the fixed spatial cell containing x,z.
+func (s *Snapshot) Candidates(dimension string, x, z float32) []*PlayerClaim {
+	if s == nil {
+		return nil
+	}
+	return s.cells[dimension][cellFor(x, z)]
+}
+
+// Supported reports whether this process understands snapshot policy and schema.
+func (s *Snapshot) Supported() bool {
+	return s != nil && s.PolicyVersion == PolicyVersion && s.SchemaVersion == SchemaVersion
+}
+
+// Age returns elapsed time since claims were last fetched or revalidated.
+func (s *Snapshot) Age(now time.Time) time.Duration {
+	if s == nil || s.FetchedAt.IsZero() {
+		return time.Duration(math.MaxInt64)
+	}
+	return max(now.Sub(s.FetchedAt), 0)
+}
+
+// BuildSnapshot fully validates, clones, and indexes claims before publication.
+func BuildSnapshot(claims map[string]PlayerClaim, generation uint64, now time.Time) (*Snapshot, error) {
+	snapshot := &Snapshot{
+		PolicyVersion: PolicyVersion,
+		SchemaVersion: SchemaVersion,
+		Generation:    generation,
+		GeneratedAt:   now,
+		FetchedAt:     now,
+		ClaimCount:    len(claims),
+		claims:        make([]PlayerClaim, 0, len(claims)),
+		cells:         make(map[string]map[cellKey][]*PlayerClaim),
+	}
+	ids := make(map[string]struct{}, len(claims))
+	for key, source := range claims {
+		cl, err := cloneAndValidateClaim(key, source)
+		if err != nil {
+			return nil, err
+		}
+		if _, exists := ids[cl.ID]; exists {
+			return nil, fmt.Errorf("duplicate claim id %q", cl.ID)
+		}
+		ids[cl.ID] = struct{}{}
+		snapshot.claims = append(snapshot.claims, cl)
+	}
+	for i := range snapshot.claims {
+		cl := &snapshot.claims[i]
+		dimensionCells := snapshot.cells[cl.Location.Dimension]
+		if dimensionCells == nil {
+			dimensionCells = make(map[cellKey][]*PlayerClaim)
+			snapshot.cells[cl.Location.Dimension] = dimensionCells
+		}
+		minCell, ok := checkedCellFor(
+			min(cl.Location.Pos1.X, cl.Location.Pos2.X),
+			min(cl.Location.Pos1.Z, cl.Location.Pos2.Z),
+		)
+		if !ok {
+			return nil, fmt.Errorf("claim %q bounds exceed spatial index", cl.ID)
+		}
+		maxCell, ok := checkedCellFor(
+			max(cl.Location.Pos1.X, cl.Location.Pos2.X),
+			max(cl.Location.Pos1.Z, cl.Location.Pos2.Z),
+		)
+		if !ok {
+			return nil, fmt.Errorf("claim %q bounds exceed spatial index", cl.ID)
+		}
+		width := int64(maxCell.x) - int64(minCell.x) + 1
+		depth := int64(maxCell.z) - int64(minCell.z) + 1
+		if width > maxCellsPerClaim || depth > maxCellsPerClaim ||
+			width*depth > maxCellsPerClaim {
+			return nil, fmt.Errorf("claim %q spans too many spatial cells", cl.ID)
+		}
+		for x := int64(minCell.x); x <= int64(maxCell.x); x++ {
+			for z := int64(minCell.z); z <= int64(maxCell.z); z++ {
+				key := cellKey{x: int32(x), z: int32(z)}
+				if len(dimensionCells[key]) == 0 {
+					snapshot.CellCount++
+				}
+				dimensionCells[key] = append(dimensionCells[key], cl)
+			}
+		}
+	}
+	return snapshot, nil
+}
+
+func cloneAndValidateClaim(key string, source PlayerClaim) (PlayerClaim, error) {
+	cl := source
+	if cl.ID == "" {
+		cl.ID = key
+	}
+	if cl.ID == "" || cl.OwnerXUID == "" {
+		return PlayerClaim{}, fmt.Errorf("claim %q missing id or owner", key)
+	}
+	dimension, ok := CanonicalDimension(cl.Location.Dimension)
+	if !ok {
+		return PlayerClaim{}, fmt.Errorf("claim %q has invalid dimension %q", cl.ID, cl.Location.Dimension)
+	}
+	cl.Location.Dimension = dimension
+	if !finite2(cl.Location.Pos1) || !finite2(cl.Location.Pos2) {
+		return PlayerClaim{}, fmt.Errorf("claim %q has non-finite bounds", cl.ID)
+	}
+	cl.TrustedXUIDS = append([]string(nil), source.TrustedXUIDS...)
+	cl.Features = make([]Feature, len(source.Features))
+	for i, feature := range source.Features {
+		if err := validateFeature(cl.ID, feature); err != nil {
+			return PlayerClaim{}, err
+		}
+		cl.Features[i] = cloneFeature(feature)
+	}
+	return cl, nil
+}
+
+func validateFeature(claimID string, feature Feature) error {
+	switch feature.Type {
+	case FeatureTypeMineable, FeatureTypeBlockPlaceable, FeatureTypeBlockInteractable,
+		FeatureTypeEntityInteractable, FeatureTypeEntityHurt, FeatureTypeDropItems:
+	default:
+		return fmt.Errorf("claim %q has unsupported feature %q", claimID, feature.Type)
+	}
+	if feature.FromLocation != nil && !finite3(*feature.FromLocation) {
+		return fmt.Errorf("claim %q has non-finite feature start", claimID)
+	}
+	if feature.ToLocation != nil && !finite3(*feature.ToLocation) {
+		return fmt.Errorf("claim %q has non-finite feature end", claimID)
+	}
+	return nil
+}
+
+func cloneFeature(source Feature) Feature {
+	feature := source
+	if source.FromLocation != nil {
+		from := *source.FromLocation
+		feature.FromLocation = &from
+	}
+	if source.ToLocation != nil {
+		to := *source.ToLocation
+		feature.ToLocation = &to
+	}
+	feature.BlockTypeIDs = append([]string(nil), source.BlockTypeIDs...)
+	feature.EntityTypeIDs = append([]string(nil), source.EntityTypeIDs...)
+	feature.ItemTypeIDs = append([]string(nil), source.ItemTypeIDs...)
+	return feature
+}
+
+// CanonicalDimension normalizes vanilla aliases and validates namespaced IDs.
+func CanonicalDimension(value string) (string, bool) {
+	value = strings.ToLower(strings.TrimSpace(value))
+	switch value {
+	case "overworld":
+		value = "minecraft:overworld"
+	case "nether":
+		value = "minecraft:nether"
+	case "end", "the_end":
+		value = "minecraft:end"
+	}
+	parts := strings.Split(value, ":")
+	return value, len(parts) == 2 && parts[0] != "" && parts[1] != ""
+}
+
+func cellFor(x, z float32) cellKey {
+	return cellKey{
+		x: int32(math.Floor(float64(x) / cellSize)),
+		z: int32(math.Floor(float64(z) / cellSize)),
+	}
+}
+
+func checkedCellFor(x, z float32) (cellKey, bool) {
+	cellX := math.Floor(float64(x) / cellSize)
+	cellZ := math.Floor(float64(z) / cellSize)
+	if cellX < math.MinInt32 || cellX > math.MaxInt32 ||
+		cellZ < math.MinInt32 || cellZ > math.MaxInt32 {
+		return cellKey{}, false
+	}
+	return cellKey{x: int32(cellX), z: int32(cellZ)}, true
+}
+
+func finite2(v Vector2) bool {
+	return !float32Invalid(v.X) && !float32Invalid(v.Z)
+}
+
+func finite3(v Vector3) bool {
+	return !float32Invalid(v.X) && !float32Invalid(v.Y) && !float32Invalid(v.Z)
+}
+
+func float32Invalid(v float32) bool {
+	return math.IsNaN(float64(v)) || math.IsInf(float64(v), 0)
+}

--- a/gobds/claim/snapshot_test.go
+++ b/gobds/claim/snapshot_test.go
@@ -1,0 +1,83 @@
+package claim
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+func TestBuildSnapshotIndexesCanonicalCellsAndClones(t *testing.T) {
+	source := map[string]PlayerClaim{
+		"one": {
+			OwnerXUID: "owner",
+			Location: Location{
+				Dimension: "OVERWORLD",
+				Pos1:      Vector2{X: -17, Z: -1},
+				Pos2:      Vector2{X: 16, Z: 16},
+			},
+			Features: []Feature{{
+				Type:         FeatureTypeMineable,
+				BlockTypeIDs: []string{"minecraft:stone"},
+			}},
+			TrustedXUIDS: []string{"trusted"},
+		},
+	}
+	now := time.Unix(100, 0)
+	snapshot, err := BuildSnapshot(source, 7, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if snapshot.Generation != 7 || snapshot.ClaimCount != 1 || snapshot.CellCount != 12 {
+		t.Fatalf("unexpected metadata: %+v", snapshot)
+	}
+	if candidates := snapshot.Candidates("minecraft:overworld", -16, 0); len(candidates) != 1 {
+		t.Fatalf("expected indexed claim, got %d candidates", len(candidates))
+	}
+	source["one"].Features[0].BlockTypeIDs[0] = "minecraft:dirt"
+	source["one"].TrustedXUIDS[0] = "changed"
+	if snapshot.claims[0].Features[0].BlockTypeIDs[0] != "minecraft:stone" ||
+		snapshot.claims[0].TrustedXUIDS[0] != "trusted" {
+		t.Fatal("snapshot retained mutable source slices")
+	}
+}
+
+func TestBuildSnapshotRejectsInvalidDataAtomically(t *testing.T) {
+	_, err := BuildSnapshot(map[string]PlayerClaim{
+		"bad": {
+			OwnerXUID: "owner",
+			Location: Location{
+				Dimension: "unknown",
+				Pos1:      Vector2{X: float32(math.NaN())},
+			},
+		},
+	}, 1, time.Now())
+	if err == nil {
+		t.Fatal("invalid claim must reject entire snapshot")
+	}
+}
+
+func TestSnapshotCellsExposeOverlapWithoutChoosingWinner(t *testing.T) {
+	claims := map[string]PlayerClaim{
+		"one": testSnapshotClaim("one", 0, 15),
+		"two": testSnapshotClaim("two", 8, 20),
+	}
+	snapshot, err := BuildSnapshot(claims, 1, time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if candidates := snapshot.Candidates("minecraft:overworld", 9, 9); len(candidates) != 2 {
+		t.Fatalf("overlap must retain both candidates, got %d", len(candidates))
+	}
+}
+
+func testSnapshotClaim(id string, minPosition, maxPosition float32) PlayerClaim {
+	return PlayerClaim{
+		ID:        id,
+		OwnerXUID: "owner",
+		Location: Location{
+			Dimension: "minecraft:overworld",
+			Pos1:      Vector2{X: minPosition, Z: minPosition},
+			Pos2:      Vector2{X: maxPosition, Z: maxPosition},
+		},
+	}
+}

--- a/gobds/config.go
+++ b/gobds/config.go
@@ -4,6 +4,7 @@ package gobds
 import (
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/sandertv/gophertunnel/minecraft"
 	"github.com/smell-of-curry/gobds/gobds/claim"
@@ -26,6 +27,12 @@ type Config struct {
 	AFKTimer              *infra.AFKTimer
 	Whitelist             *whitelist.Whitelist
 	Border                *area.Area2D
+	ClaimPrefilter        bool
+	ClaimDenyRendering    bool
+	ClaimPollInterval     time.Duration
+	ClaimMaxSnapshotAge   time.Duration
+	TrafficProtection     session.TrafficConfig
+	DuplicateXUIDEnabled  bool
 	Log                   *slog.Logger
 }
 
@@ -33,6 +40,18 @@ type Config struct {
 func (c UserConfig) Config(log *slog.Logger) (Config, error) {
 	if len(c.Network.Servers) == 0 {
 		return Config{}, fmt.Errorf("no servers configured")
+	}
+
+	pollInterval, err := claimDuration(c.Claims.PollInterval, claim.DefaultPollInterval)
+	if err != nil {
+		return Config{}, fmt.Errorf("claims poll interval: %w", err)
+	}
+	maxSnapshotAge, err := claimDuration(c.Claims.MaxSnapshotAge, claim.DefaultMaxSnapshotAge)
+	if err != nil {
+		return Config{}, fmt.Errorf("claims max snapshot age: %w", err)
+	}
+	if maxSnapshotAge < pollInterval {
+		return Config{}, fmt.Errorf("claims max snapshot age must be at least poll interval")
 	}
 
 	conf := Config{
@@ -44,14 +63,20 @@ func (c UserConfig) Config(log *slog.Logger) (Config, error) {
 			URL:     c.VPNService.URL,
 			Key:     c.VPNService.Key,
 		}, c.VPNService.WhitelistedCIDRs),
-		AFKTimer:  c.afkTimer(),
-		Whitelist: c.whiteList(log),
-		Border:    c.makeBorder(),
-		Log:       log,
+		AFKTimer:             c.afkTimer(),
+		Whitelist:            c.whiteList(log),
+		Border:               c.makeBorder(),
+		ClaimPrefilter:       c.Claims.PrefilterEnabled,
+		ClaimDenyRendering:   c.Claims.DenyRenderingEnabled,
+		ClaimPollInterval:    pollInterval,
+		ClaimMaxSnapshotAge:  maxSnapshotAge,
+		TrafficProtection:    c.TrafficProtection.WithDefaults(),
+		DuplicateXUIDEnabled: c.DuplicateXUID.Enabled,
+		Log:                  log,
 	}
 	session.SetCommandPath(c.Resources.CommandPath)
 
-	err := c.loadCommands(log)
+	err = c.loadCommands(log)
 	if err != nil {
 		return conf, fmt.Errorf("error loading commands: %w", err)
 	}
@@ -62,7 +87,14 @@ func (c UserConfig) Config(log *slog.Logger) (Config, error) {
 			LocalAddress:  server.LocalAddress,
 			RemoteAddress: server.RemoteAddress,
 
-			ClaimFactory: claim.NewFactory(server.ClaimService, log),
+			ClaimFactory: claim.NewFactory(
+				server.ClaimService,
+				server.Name,
+				pollInterval,
+				maxSnapshotAge,
+				log.With(slog.String("srv", server.Name)),
+			),
+			TrafficMetrics: &session.TrafficMetrics{},
 
 			DialerFunc: c.dialerFunc(server.RemoteAddress, log),
 
@@ -85,4 +117,15 @@ func (c UserConfig) Config(log *slog.Logger) (Config, error) {
 		conf.Servers = append(conf.Servers, srv)
 	}
 	return conf, nil
+}
+
+func claimDuration(value string, fallback time.Duration) (time.Duration, error) {
+	if value == "" {
+		return fallback, nil
+	}
+	duration, err := time.ParseDuration(value)
+	if err != nil || duration <= 0 {
+		return 0, fmt.Errorf("must be a positive duration")
+	}
+	return duration, nil
 }

--- a/gobds/config_test.go
+++ b/gobds/config_test.go
@@ -1,0 +1,52 @@
+package gobds
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/smell-of-curry/gobds/gobds/claim"
+	"github.com/smell-of-curry/gobds/gobds/session"
+)
+
+func TestClaimHardeningDefaultsOff(t *testing.T) {
+	config := DefaultConfig()
+	if config.Claims.PrefilterEnabled || config.Claims.DenyRenderingEnabled {
+		t.Fatal("claim prefilter and deny rendering must default off")
+	}
+}
+
+func TestClaimDurationsDefaultDuringConfigConversion(t *testing.T) {
+	config := UserConfig{}
+	config.Network.Servers = []ServerConfig{{
+		Name:          "test",
+		LocalAddress:  "127.0.0.1:19132",
+		RemoteAddress: "127.0.0.1:19133",
+	}}
+	config.Resources.CommandPath = filepath.Join(t.TempDir(), "commands.json")
+	if err := os.WriteFile(config.Resources.CommandPath, []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runtime, err := config.Config(slog.Default())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if runtime.ClaimPollInterval != claim.DefaultPollInterval ||
+		runtime.ClaimMaxSnapshotAge != claim.DefaultMaxSnapshotAge {
+		t.Fatalf(
+			"unexpected defaults: poll=%s maxAge=%s",
+			runtime.ClaimPollInterval,
+			runtime.ClaimMaxSnapshotAge,
+		)
+	}
+	if runtime.Servers[0].ClaimFactory.PollInterval() != claim.DefaultPollInterval {
+		t.Fatal("factory did not receive default poll interval")
+	}
+	defaultTraffic := session.DefaultTrafficConfig()
+	if runtime.TrafficProtection.Enforce ||
+		runtime.TrafficProtection.Chat != defaultTraffic.Chat ||
+		runtime.TrafficProtection.MaxInventoryActions != defaultTraffic.MaxInventoryActions {
+		t.Fatalf("missing traffic section did not receive defaults: %+v", runtime.TrafficProtection)
+	}
+}

--- a/gobds/entity/entity.go
+++ b/gobds/entity/entity.go
@@ -1,18 +1,29 @@
 // Package entity provides entity-related functionality for the GoBDS proxy.
 package entity
 
+import "github.com/go-gl/mathgl/mgl32"
+
 // Entity ...
 type Entity struct {
+	uniqueID  int64
 	runtimeID uint64
 	actorType string
+	position  mgl32.Vec3
 }
 
 // NewEntity ...
-func NewEntity(runtimeID uint64, actorType string) Entity {
+func NewEntity(uniqueID int64, runtimeID uint64, actorType string, position mgl32.Vec3) Entity {
 	return Entity{
+		uniqueID:  uniqueID,
 		runtimeID: runtimeID,
 		actorType: actorType,
+		position:  position,
 	}
+}
+
+// UniqueID ...
+func (e Entity) UniqueID() int64 {
+	return e.uniqueID
 }
 
 // RuntimeID ...
@@ -23,4 +34,9 @@ func (e Entity) RuntimeID() uint64 {
 // ActorType ...
 func (e Entity) ActorType() string {
 	return e.actorType
+}
+
+// Position ...
+func (e Entity) Position() mgl32.Vec3 {
+	return e.position
 }

--- a/gobds/entity/factory.go
+++ b/gobds/entity/factory.go
@@ -4,18 +4,22 @@ import (
 	"maps"
 	"slices"
 	"sync"
+
+	"github.com/go-gl/mathgl/mgl32"
 )
 
 // Factory ...
 type Factory struct {
-	entities map[uint64]Entity
-	mu       sync.RWMutex
+	entities            map[uint64]Entity
+	runtimeIDByUniqueID map[int64]uint64
+	mu                  sync.RWMutex
 }
 
 // NewFactory ...
 func NewFactory() *Factory {
 	return &Factory{
-		entities: make(map[uint64]Entity),
+		entities:            make(map[uint64]Entity),
+		runtimeIDByUniqueID: make(map[int64]uint64),
 	}
 }
 
@@ -23,14 +27,56 @@ func NewFactory() *Factory {
 func (f *Factory) Add(e Entity) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	if previous, ok := f.entities[e.RuntimeID()]; ok {
+		delete(f.runtimeIDByUniqueID, previous.UniqueID())
+	}
+	if previousRuntimeID, ok := f.runtimeIDByUniqueID[e.UniqueID()]; ok {
+		delete(f.entities, previousRuntimeID)
+	}
 	f.entities[e.RuntimeID()] = e
+	f.runtimeIDByUniqueID[e.UniqueID()] = e.RuntimeID()
 }
 
 // RemoveFromRuntimeID ...
 func (f *Factory) RemoveFromRuntimeID(runtimeID uint64) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	if e, ok := f.entities[runtimeID]; ok {
+		delete(f.runtimeIDByUniqueID, e.UniqueID())
+	}
 	delete(f.entities, runtimeID)
+}
+
+// RemoveFromUniqueID ...
+func (f *Factory) RemoveFromUniqueID(uniqueID int64) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	runtimeID, ok := f.runtimeIDByUniqueID[uniqueID]
+	if !ok {
+		return
+	}
+	delete(f.runtimeIDByUniqueID, uniqueID)
+	delete(f.entities, runtimeID)
+}
+
+// UpdatePosition updates selected absolute position components.
+func (f *Factory) UpdatePosition(runtimeID uint64, position mgl32.Vec3, updateX, updateY, updateZ bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	e, ok := f.entities[runtimeID]
+	if !ok {
+		return
+	}
+	if updateX {
+		e.position[0] = position[0]
+	}
+	if updateY {
+		e.position[1] = position[1]
+	}
+	if updateZ {
+		e.position[2] = position[2]
+	}
+	f.entities[runtimeID] = e
 }
 
 // ByRuntimeID ...

--- a/gobds/entity/factory_test.go
+++ b/gobds/entity/factory_test.go
@@ -1,0 +1,29 @@
+package entity
+
+import (
+	"testing"
+
+	"github.com/go-gl/mathgl/mgl32"
+)
+
+func TestFactoryRemovesEntityByUniqueID(t *testing.T) {
+	factory := NewFactory()
+	factory.Add(NewEntity(7, 42, "minecraft:armor_stand", mgl32.Vec3{}))
+	factory.RemoveFromUniqueID(7)
+	if _, ok := factory.ByRuntimeID(42); ok {
+		t.Fatal("entity remained after removal by unique ID")
+	}
+}
+
+func TestFactoryUpdatesPartialPosition(t *testing.T) {
+	factory := NewFactory()
+	factory.Add(NewEntity(7, 42, "minecraft:armor_stand", mgl32.Vec3{1, 2, 3}))
+	factory.UpdatePosition(42, mgl32.Vec3{4, 0, 6}, true, false, true)
+	entity, ok := factory.ByRuntimeID(42)
+	if !ok {
+		t.Fatal("entity missing after position update")
+	}
+	if entity.Position() != (mgl32.Vec3{4, 2, 6}) {
+		t.Fatalf("unexpected entity position: %v", entity.Position())
+	}
+}

--- a/gobds/gobds.go
+++ b/gobds/gobds.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/df-mc/dragonfly/server/world"
 	"github.com/sandertv/gophertunnel/minecraft"
+	"github.com/sandertv/gophertunnel/minecraft/protocol"
 	"github.com/sandertv/gophertunnel/minecraft/text"
 	_ "github.com/smell-of-curry/gobds/gobds/block"
 	"github.com/smell-of-curry/gobds/gobds/entity"
@@ -42,6 +43,7 @@ func (c *Config) New() (*GoBDS, error) {
 	c.Log.Info("creating a new instance of gobds")
 	ctx, cancel := context.WithCancel(context.Background())
 	world.DefaultBlockRegistry.Finalize()
+	session.SetupRuntimeIDs()
 
 	gobds := &GoBDS{
 		conf:   c,
@@ -64,7 +66,7 @@ func (gb *GoBDS) Listen() error {
 		return fmt.Errorf("start gobds: already started")
 	}
 
-	gb.conf.Log.Info("starting gobds")
+	gb.conf.Log.Info("starting gobds", "mc-version", protocol.CurrentVersion)
 
 	gb.wg.Add(len(gb.servers))
 	for _, srv := range gb.servers {
@@ -107,6 +109,14 @@ func (gb *GoBDS) listen(srv *Server) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
+			xuid := conn.IdentityData().XUID
+			if gb.conf.DuplicateXUIDEnabled {
+				if !srv.ReserveXUID(xuid) {
+					_ = srv.Listener.Disconnect(conn, "This account is already connected.")
+					return
+				}
+				defer srv.ReleaseXUID(xuid)
+			}
 
 			s, err := gb.accept(conn, srv, ctx)
 			if err != nil {
@@ -123,6 +133,8 @@ func (gb *GoBDS) listen(srv *Server) {
 	}
 }
 
+var errInvalidJoinPath = errors.New("you must join through the server hub to play")
+
 // accept accepts new connection.
 func (gb *GoBDS) accept(conn session.Conn, srv *Server, ctx context.Context) (*session.Session, error) {
 	identityData := conn.IdentityData()
@@ -136,12 +148,12 @@ func (gb *GoBDS) accept(conn session.Conn, srv *Server, ctx context.Context) (*s
 		if err != nil {
 			disconnectionMessage := err.Error()
 			if errors.Is(err, authentication.ErrRecordNotFound) {
-				disconnectionMessage = text.Colourf("<red>you must join through the server hub.</red>")
+				disconnectionMessage = text.Colourf("<red>%s.</red>", errInvalidJoinPath.Error())
 			}
 			return nil, errors.New(disconnectionMessage)
 		}
 		if !response.Allowed {
-			return nil, fmt.Errorf("you must join through the server hub to play")
+			return nil, errInvalidJoinPath
 		}
 	}
 
@@ -258,7 +270,7 @@ func (gb *GoBDS) startGame(conn, serverConn session.Conn, srv *Server, ctx conte
 		Client: conn,
 		Server: serverConn,
 
-		AFKTimer:      gb.conf.AFKTimer,
+		AFKTimer: gb.conf.AFKTimer,
 
 		// EntityFactory must be per-session: each session has its own backend connection
 		// and BDS issues runtime IDs scoped to that connection. Sharing this map between
@@ -267,8 +279,12 @@ func (gb *GoBDS) startGame(conn, serverConn session.Conn, srv *Server, ctx conte
 		EntityFactory: entity.NewFactory(),
 		ClaimFactory:  srv.ClaimFactory,
 
-		Border: gb.conf.Border,
-		Log:    gb.conf.Log,
+		Border:             gb.conf.Border,
+		ClaimPrefilter:     gb.conf.ClaimPrefilter,
+		ClaimDenyRendering: gb.conf.ClaimDenyRendering,
+		Traffic:            gb.conf.TrafficProtection,
+		TrafficMetrics:     srv.TrafficMetrics,
+		Log:                gb.conf.Log,
 	}.New()
 
 	s.ForwardXUID(gb.conf.EncryptionKey)

--- a/gobds/server.go
+++ b/gobds/server.go
@@ -3,6 +3,7 @@ package gobds
 import (
 	"context"
 	"log/slog"
+	"os"
 	"sync"
 	"time"
 
@@ -37,6 +38,8 @@ type Server struct {
 	// ClaimFactory is shared across all sessions on this server because claims are world-state
 	// fetched periodically from an external service.
 	ClaimFactory *claim.Factory
+	// TrafficMetrics aggregates rate and malformed-packet counters for this server.
+	TrafficMetrics *session.TrafficMetrics
 
 	Listener       Listener
 	StatusProvider minecraft.ServerStatusProvider
@@ -49,8 +52,37 @@ type Server struct {
 	// pointer so late-registering sessions with duplicate XUIDs (e.g. a
 	// reconnect racing with an old connection) don't clobber one another.
 	sessions sync.Map
+	xuidMu   sync.Mutex
+	xuids    map[string]struct{}
 
 	Log *slog.Logger
+}
+
+// ReserveXUID atomically reserves a non-empty XUID until ReleaseXUID is called.
+func (s *Server) ReserveXUID(xuid string) bool {
+	if xuid == "" {
+		return true
+	}
+	s.xuidMu.Lock()
+	defer s.xuidMu.Unlock()
+	if s.xuids == nil {
+		s.xuids = make(map[string]struct{})
+	}
+	if _, exists := s.xuids[xuid]; exists {
+		return false
+	}
+	s.xuids[xuid] = struct{}{}
+	return true
+}
+
+// ReleaseXUID releases an admission reservation.
+func (s *Server) ReleaseXUID(xuid string) {
+	if xuid == "" {
+		return
+	}
+	s.xuidMu.Lock()
+	delete(s.xuids, xuid)
+	s.xuidMu.Unlock()
 }
 
 // AddSession registers a session with the server for later iteration by the
@@ -138,14 +170,28 @@ func (gb *GoBDS) claimFetching(srv *Server) {
 		}
 	}
 	fetch()
-	t := time.NewTicker(5 * time.Minute)
-	defer t.Stop()
+	refresh := time.NewTicker(srv.ClaimFactory.PollInterval())
+	defer refresh.Stop()
+	const metricPeriod = time.Minute
+	metrics := time.NewTicker(metricPeriod)
+	defer metrics.Stop()
 	for {
 		select {
 		case <-gb.ctx.Done():
 			return
-		case <-t.C:
+		case <-refresh.C:
 			fetch()
+		case <-metrics.C:
+			srv.ClaimFactory.Metrics().WriteDelta(os.Stdout, metricPeriod, snapshotOf(srv.ClaimFactory))
+			srv.TrafficMetrics.WriteDelta(os.Stdout, srv.Name, "", metricPeriod)
+			for _, sess := range srv.Sessions() {
+				sess.WriteTrafficMetrics(os.Stdout, srv.Name, metricPeriod)
+			}
 		}
 	}
+}
+
+func snapshotOf(factory *claim.Factory) *claim.Snapshot {
+	snapshot, _ := factory.Snapshot(time.Now())
+	return snapshot
 }

--- a/gobds/server_test.go
+++ b/gobds/server_test.go
@@ -1,0 +1,40 @@
+package gobds
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+func TestXUIDReservationRejectsSimultaneousAndAllowsReconnect(t *testing.T) {
+	server := &Server{}
+	if !server.ReserveXUID("123") {
+		t.Fatal("first reservation rejected")
+	}
+	if server.ReserveXUID("123") {
+		t.Fatal("simultaneous reservation accepted")
+	}
+	server.ReleaseXUID("123")
+	if !server.ReserveXUID("123") {
+		t.Fatal("reconnect rejected after release")
+	}
+}
+
+func TestXUIDReservationIsAtomic(t *testing.T) {
+	server := &Server{}
+	var accepted atomic.Int32
+	var group sync.WaitGroup
+	for range 32 {
+		group.Add(1)
+		go func() {
+			defer group.Done()
+			if server.ReserveXUID("same") {
+				accepted.Add(1)
+			}
+		}()
+	}
+	group.Wait()
+	if accepted.Load() != 1 {
+		t.Fatalf("accepted %d simultaneous reservations", accepted.Load())
+	}
+}

--- a/gobds/service/authentication/service.go
+++ b/gobds/service/authentication/service.go
@@ -35,7 +35,7 @@ func (s *Service) AuthenticationOf(xuid string, ctx context.Context) (*ResponseM
 	var lastErr error
 	for attempt := 0; attempt <= service.MaxRetries; attempt++ {
 		if s.Closed {
-			break
+			return nil, fmt.Errorf("service closed")
 		}
 		if attempt > 0 {
 			time.Sleep(service.RetryDelay)
@@ -55,26 +55,33 @@ func (s *Service) AuthenticationOf(xuid string, ctx context.Context) (*ResponseM
 			}
 			return nil, lastErr
 		}
-		defer func() { _ = response.Body.Close() }()
 
 		switch response.StatusCode {
 		case http.StatusNotFound:
-			lastErr = ErrRecordNotFound
+			_ = response.Body.Close()
+			return nil, ErrRecordNotFound
 		case http.StatusGone:
-			lastErr = fmt.Errorf("found expired authentication record found for: %s", xuid)
+			_ = response.Body.Close()
+			return nil, fmt.Errorf("expired authentication record for: %s", xuid)
 		case http.StatusOK:
 			var responseModel ResponseModel
 			if err = json.NewDecoder(response.Body).Decode(&responseModel); err != nil {
-				return nil, err
+				_ = response.Body.Close()
+				return nil, fmt.Errorf("failed to decode response: %w", err)
 			}
+			_ = response.Body.Close()
 			return &responseModel, nil
 		case http.StatusTooManyRequests:
+			_ = response.Body.Close()
 			lastErr = fmt.Errorf("rate limited")
-			time.Sleep(time.Duration(attempt+1) * service.RetryDelay)
 			continue
 		default:
+			_ = response.Body.Close()
 			lastErr = fmt.Errorf("unexpected status code: %d", response.StatusCode)
 		}
+	}
+	if lastErr == nil {
+		lastErr = fmt.Errorf("authentication service unavailable")
 	}
 	return nil, lastErr
 }

--- a/gobds/service/vpn/service.go
+++ b/gobds/service/vpn/service.go
@@ -57,7 +57,7 @@ func (s *Service) CheckIP(ip string, ctx context.Context) (*ResponseModel, error
 	var lastErr error
 	for attempt := 0; attempt <= 1; attempt++ {
 		if s.Closed {
-			break
+			return nil, fmt.Errorf("service closed")
 		}
 		if attempt > 0 {
 			time.Sleep(service.RetryDelay)
@@ -98,13 +98,13 @@ func (s *Service) CheckIP(ip string, ctx context.Context) (*ResponseModel, error
 			}
 			return &responseModel, nil
 		case http.StatusTooManyRequests:
+			_ = response.Body.Close()
 			lastErr = fmt.Errorf("rate limited by api")
-			time.Sleep(time.Duration(attempt+1) * service.RetryDelay)
 			continue
 		default:
+			_ = response.Body.Close()
 			lastErr = fmt.Errorf("unexpected status code: %d", response.StatusCode)
 		}
-		_ = response.Body.Close()
 	}
 	return nil, lastErr
 }

--- a/gobds/session/claim_policy_golden_test.go
+++ b/gobds/session/claim_policy_golden_test.go
@@ -42,7 +42,7 @@ func TestClaimPolicyGoldenFixture(t *testing.T) {
 	}
 	for _, test := range golden.Cases {
 		t.Run(test.Name, func(t *testing.T) {
-			action := claimActionFromGolden(test.Action)
+			action := claimActionFromGolden(t, test.Action)
 			got := ClaimActionPermitted(
 				test.Claim,
 				ClaimActor{XUID: test.Actor.XUID, Operator: test.Actor.Operator},
@@ -59,7 +59,8 @@ func TestClaimPolicyGoldenFixture(t *testing.T) {
 	}
 }
 
-func claimActionFromGolden(value string) ClaimAction {
+func claimActionFromGolden(t *testing.T, value string) ClaimAction {
+	t.Helper()
 	switch value {
 	case "render":
 		return ClaimActionRender
@@ -80,6 +81,7 @@ func claimActionFromGolden(value string) ClaimAction {
 	case "itemDrop":
 		return ClaimActionItemDrop
 	default:
-		return ClaimAction(255)
+		t.Fatalf("unknown golden action: %q", value)
+		return 0
 	}
 }

--- a/gobds/session/claim_policy_golden_test.go
+++ b/gobds/session/claim_policy_golden_test.go
@@ -1,0 +1,85 @@
+package session
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/go-gl/mathgl/mgl32"
+	"github.com/smell-of-curry/gobds/gobds/claim"
+)
+
+type policyGolden struct {
+	SchemaVersion int                `json:"schemaVersion"`
+	PolicyVersion int                `json:"policyVersion"`
+	Cases         []policyGoldenCase `json:"cases"`
+}
+
+type policyGoldenCase struct {
+	Name  string            `json:"name"`
+	Claim claim.PlayerClaim `json:"claim"`
+	Actor struct {
+		XUID     string `json:"xuid"`
+		Operator bool   `json:"operator"`
+	} `json:"actor"`
+	Action    string        `json:"action"`
+	Position  claim.Vector3 `json:"position"`
+	TypeID    string        `json:"typeId"`
+	Permitted bool          `json:"permitted"`
+}
+
+func TestClaimPolicyGoldenFixture(t *testing.T) {
+	raw, err := os.ReadFile("../../policy/claim_policy.v1.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var golden policyGolden
+	if err = json.Unmarshal(raw, &golden); err != nil {
+		t.Fatal(err)
+	}
+	if golden.SchemaVersion != claim.SchemaVersion || golden.PolicyVersion != claim.PolicyVersion {
+		t.Fatalf("unsupported golden versions: schema=%d policy=%d", golden.SchemaVersion, golden.PolicyVersion)
+	}
+	for _, test := range golden.Cases {
+		t.Run(test.Name, func(t *testing.T) {
+			action := claimActionFromGolden(test.Action)
+			got := ClaimActionPermitted(
+				test.Claim,
+				ClaimActor{XUID: test.Actor.XUID, Operator: test.Actor.Operator},
+				action,
+				claimActionData{
+					position: mgl32.Vec3{test.Position.X, test.Position.Y, test.Position.Z},
+					typeID:   test.TypeID,
+				},
+			)
+			if got != test.Permitted {
+				t.Fatalf("permitted = %v, want %v", got, test.Permitted)
+			}
+		})
+	}
+}
+
+func claimActionFromGolden(value string) ClaimAction {
+	switch value {
+	case "render":
+		return ClaimActionRender
+	case "blockBreak":
+		return ClaimActionBlockBreak
+	case "blockPlace":
+		return ClaimActionBlockPlace
+	case "blockInteract":
+		return ClaimActionBlockInteract
+	case "entityInteract":
+		return ClaimActionEntityInteract
+	case "entityHurt":
+		return ClaimActionEntityHurt
+	case "itemRelease":
+		return ClaimActionItemRelease
+	case "itemThrow":
+		return ClaimActionItemThrow
+	case "itemDrop":
+		return ClaimActionItemDrop
+	default:
+		return ClaimAction(255)
+	}
+}

--- a/gobds/session/config.go
+++ b/gobds/session/config.go
@@ -16,8 +16,13 @@ type Config struct {
 	Client Conn
 	Server Conn
 
-	AFKTimer      *infra.AFKTimer
-	Border        *area.Area2D
+	AFKTimer *infra.AFKTimer
+	Border   *area.Area2D
+
+	ClaimPrefilter     bool
+	ClaimDenyRendering bool
+	Traffic            TrafficConfig
+	TrafficMetrics     *TrafficMetrics
 
 	EntityFactory *entity.Factory
 	ClaimFactory  *claim.Factory
@@ -34,10 +39,17 @@ func (c Config) New() *Session {
 		afkTimer: c.AFKTimer,
 		border:   c.Border,
 
+		claimPrefilter:     c.ClaimPrefilter,
+		claimDenyRendering: c.ClaimDenyRendering,
+
 		entityFactory: c.EntityFactory,
 		claimFactory:  c.ClaimFactory,
 
 		close: make(chan struct{}),
+		corrective: correctiveState{
+			last: make(map[correctiveKey]time.Time),
+		},
+		traffic: newTrafficState(c.Traffic, c.TrafficMetrics),
 
 		lastForwardedPing: -1,
 
@@ -45,6 +57,7 @@ func (c Config) New() *Session {
 		log:  c.Log,
 	}
 	s.afk.lastMoveTime = time.Now()
+	s.afk.lastPosition = c.Client.GameData().PlayerPosition
 	s.registerHandlers()
 	return s
 }

--- a/gobds/session/data.go
+++ b/gobds/session/data.go
@@ -3,21 +3,26 @@ package session
 import (
 	"sync/atomic"
 	"time"
+
+	"github.com/sandertv/gophertunnel/minecraft/protocol/packet"
 )
 
 // Data ...
 type Data struct {
 	dimension atomic.Int32
+	gamemode  atomic.Int32
 	lastDrop  atomic.Pointer[time.Time]
+	operator  atomic.Bool
 }
 
 // NewData ...
 func NewData(conn Conn) *Data {
 	gameData := conn.GameData()
-
 	d := &Data{}
 	d.dimension.Store(gameData.Dimension)
+	d.gamemode.Store(gameData.PlayerGameMode)
 	d.lastDrop.Store(&time.Time{})
+	d.operator.Store(gameData.PlayerPermissions == packet.PermissionLevelOperator)
 	return d
 }
 
@@ -31,6 +36,16 @@ func (d *Data) SetDimension(dimension int32) {
 	d.dimension.Store(dimension)
 }
 
+// GameMode ...
+func (d *Data) GameMode() int32 {
+	return d.gamemode.Load()
+}
+
+// SetGameMode ...
+func (d *Data) SetGameMode(mode int32) {
+	d.gamemode.Store(mode)
+}
+
 // SetLastDrop ...
 func (d *Data) SetLastDrop() {
 	now := time.Now()
@@ -39,6 +54,15 @@ func (d *Data) SetLastDrop() {
 
 // InteractWithBlock ...
 func (d *Data) InteractWithBlock() bool {
-	lastDrop := d.lastDrop.Load()
-	return time.Since(*lastDrop) > time.Millisecond*500
+	return time.Since(*d.lastDrop.Load()) > time.Millisecond*500
+}
+
+// Operator ...
+func (d *Data) Operator() bool {
+	return d.operator.Load()
+}
+
+// SetOperator ...
+func (d *Data) SetOperator(operator bool) {
+	d.operator.Store(operator)
 }

--- a/gobds/session/handler_add_actor.go
+++ b/gobds/session/handler_add_actor.go
@@ -14,11 +14,14 @@ import (
 type AddActorHandler struct{}
 
 // Handle ...
-func (*AddActorHandler) Handle(s *Session, pk packet.Packet, _ *Context) error {
+func (*AddActorHandler) Handle(s *Session, pk packet.Packet, ctx *Context) error {
+	if ctx.Val() != s.server {
+		return nil
+	}
 	pkt := pk.(*packet.AddActor)
 
 	entityType := pkt.EntityType
-	s.entityFactory.Add(entity.NewEntity(pkt.EntityRuntimeID, entityType))
+	s.entityFactory.Add(entity.NewEntity(pkt.EntityUniqueID, pkt.EntityRuntimeID, entityType, pkt.Position))
 
 	if !strings.HasPrefix(entityType, "pokemon:") {
 		return nil

--- a/gobds/session/handler_add_painting.go
+++ b/gobds/session/handler_add_painting.go
@@ -9,8 +9,16 @@ import (
 type AddPaintingHandler struct{}
 
 // Handle ...
-func (*AddPaintingHandler) Handle(s *Session, pk packet.Packet, _ *Context) error {
+func (*AddPaintingHandler) Handle(s *Session, pk packet.Packet, ctx *Context) error {
+	if ctx.Val() != s.server {
+		return nil
+	}
 	pkt := pk.(*packet.AddPainting)
-	s.entityFactory.Add(entity.NewEntity(pkt.EntityRuntimeID, "minecraft:painting"))
+	s.entityFactory.Add(entity.NewEntity(
+		pkt.EntityUniqueID,
+		pkt.EntityRuntimeID,
+		"minecraft:painting",
+		pkt.Position,
+	))
 	return nil
 }

--- a/gobds/session/handler_change_dimension.go
+++ b/gobds/session/handler_change_dimension.go
@@ -1,0 +1,14 @@
+package session
+
+import "github.com/sandertv/gophertunnel/minecraft/protocol/packet"
+
+// ChangeDimensionHandler tracks server-authoritative dimension changes.
+type ChangeDimensionHandler struct{}
+
+// Handle ...
+func (*ChangeDimensionHandler) Handle(s *Session, pk packet.Packet, ctx *Context) error {
+	if ctx.Val() == s.server {
+		s.Data().SetDimension(pk.(*packet.ChangeDimension).Dimension)
+	}
+	return nil
+}

--- a/gobds/session/handler_command_request.go
+++ b/gobds/session/handler_command_request.go
@@ -14,13 +14,29 @@ type CommandRequestHandler struct{}
 // Handle ...
 func (*CommandRequestHandler) Handle(s *Session, pk packet.Packet, ctx *Context) error {
 	pkt := pk.(*packet.CommandRequest)
-
-	cmd := strings.ToLower(strings.Split(pkt.CommandLine[1:], " ")[0])
-	if slices.Contains(disabledCommands, cmd) {
+	if ctx.Val() != s.client {
+		return nil
+	}
+	cmd, empty, err := commandName(pkt.CommandLine, s.traffic.config.MaxCommandBytes)
+	if err != nil {
+		s.traffic.malformed(trafficCommand)
+		return err
+	}
+	if empty {
+		s.traffic.malformed(trafficCommand)
 		ctx.Cancel()
 		return nil
 	}
-	if strings.ReplaceAll(cmd, " ", "") == "" {
+	if !s.traffic.allow(trafficCommand) {
+		ctx.Cancel()
+		return nil
+	}
+	if cmd == "" {
+		return nil
+	}
+
+	if slices.Contains(disabledCommands, cmd) {
+		ctx.Cancel()
 		return nil
 	}
 
@@ -38,4 +54,19 @@ func (*CommandRequestHandler) Handle(s *Session, pk packet.Packet, ctx *Context)
 	})
 	ctx.Cancel()
 	return nil
+}
+
+func commandName(line string, maxBytes int) (name string, empty bool, err error) {
+	if len(line) > maxBytes {
+		return "", false, malformedPacketError{reason: "command exceeds maximum length"}
+	}
+	line = strings.TrimSpace(line)
+	if line == "" || line == "/" {
+		return "", true, nil
+	}
+	if line[0] != '/' {
+		return "", false, nil
+	}
+	name, _, _ = strings.Cut(strings.ToLower(line[1:]), " ")
+	return name, false, nil
 }

--- a/gobds/session/handler_inventory_transaction.go
+++ b/gobds/session/handler_inventory_transaction.go
@@ -1,16 +1,14 @@
 package session
 
 import (
-	"slices"
+	"time"
 
 	"github.com/df-mc/dragonfly/server/block"
-	"github.com/df-mc/dragonfly/server/world"
-	"github.com/go-gl/mathgl/mgl32"
+	"github.com/df-mc/dragonfly/server/event"
 	"github.com/sandertv/gophertunnel/minecraft/protocol"
 	"github.com/sandertv/gophertunnel/minecraft/protocol/packet"
 	"github.com/sandertv/gophertunnel/minecraft/text"
 	gblock "github.com/smell-of-curry/gobds/gobds/block"
-	"github.com/smell-of-curry/gobds/gobds/claim"
 )
 
 // InventoryTransactionHandler ...
@@ -19,6 +17,21 @@ type InventoryTransactionHandler struct{}
 // Handle ...
 func (h *InventoryTransactionHandler) Handle(s *Session, pk packet.Packet, ctx *Context) error {
 	pkt := pk.(*packet.InventoryTransaction)
+	if ctx.Val() == s.client {
+		if len(pkt.Actions) > s.traffic.config.MaxInventoryActions {
+			s.traffic.malformed(trafficInventory)
+			return malformedPacketError{reason: "inventory transaction has too many actions"}
+		}
+		if !s.traffic.allow(trafficInventory) {
+			ctx.Cancel()
+			return nil
+		}
+	}
+	if s.claimFactory != nil {
+		s.claimFactory.Metrics().Packet()
+		start := time.Now()
+		defer func() { s.claimFactory.Metrics().Latency(time.Since(start)) }()
+	}
 
 	h.handleInteraction(s, pkt, ctx)
 	if ctx.Cancelled() {
@@ -30,8 +43,26 @@ func (h *InventoryTransactionHandler) Handle(s *Session, pk packet.Packet, ctx *
 		return nil
 	}
 
-	h.handleClaims(s, pkt, ctx)
+	if h.handleClaimsFailOpen(s, pkt, ctx.Val()) {
+		ctx.Cancel()
+	}
 	return nil
+}
+
+func (h *InventoryTransactionHandler) handleClaimsFailOpen(
+	s *Session,
+	pkt *packet.InventoryTransaction,
+	conn Conn,
+) (cancel bool) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			cancel = false
+			s.log.Error("claim inventory transaction failed open", "error", recovered)
+		}
+	}()
+	ctx := event.C(conn)
+	h.handleClaims(s, pkt, ctx)
+	return ctx.Cancelled()
 }
 
 // handleInteraction ...
@@ -48,11 +79,11 @@ func (h *InventoryTransactionHandler) handleInteraction(s *Session, pkt *packet.
 	if !ok {
 		return
 	}
-	if transactionData.ActionType != protocol.UseItemActionClickBlock &&
-		transactionData.TriggerType != protocol.UseItemActionClickAir {
+	if transactionData.ActionType != protocol.UseItemActionClickBlock ||
+		transactionData.TriggerType != protocol.TriggerTypePlayerInput {
 		return
 	}
-	b, ok := world.BlockByRuntimeID(transactionData.BlockRuntimeID)
+	b, ok := blockByRuntimeID(transactionData.BlockRuntimeID, s.GameData().UseBlockNetworkIDHashes)
 	if !ok {
 		return
 	}
@@ -75,9 +106,9 @@ func (h *InventoryTransactionHandler) handleWorldBorder(s *Session, pkt *packet.
 		return
 	}
 
-	if td, ok := pkt.TransactionData.(*protocol.UseItemTransactionData); ok {
-		if td.ActionType == protocol.UseItemActionClickBlock {
-			if !s.border.PositionInside(td.BlockPosition.X(), td.BlockPosition.Z()) {
+	if transaction, ok := pkt.TransactionData.(*protocol.UseItemTransactionData); ok {
+		if transaction.ActionType == protocol.UseItemActionClickBlock {
+			if !s.border.PositionInside(transaction.BlockPosition.X(), transaction.BlockPosition.Z()) {
 				ctx.Cancel()
 			}
 		}
@@ -86,15 +117,54 @@ func (h *InventoryTransactionHandler) handleWorldBorder(s *Session, pkt *packet.
 
 // handleClaims ...
 func (h *InventoryTransactionHandler) handleClaims(s *Session, pkt *packet.InventoryTransaction, ctx *Context) {
+	h.handleClaimDropItems(s, pkt, ctx)
+	if ctx.Cancelled() {
+		return
+	}
 	h.handleClaimUseItem(s, pkt, ctx)
 	if ctx.Cancelled() {
 		return
 	}
 	h.handleClaimUseItemOnEntity(s, pkt, ctx)
-	if ctx.Cancelled() {
+}
+
+func (*InventoryTransactionHandler) handleClaimDropItems(
+	s *Session,
+	pkt *packet.InventoryTransaction,
+	ctx *Context,
+) {
+	position := s.Position()
+	registry := s.handlers[packet.IDItemRegistry].(*ItemRegistryHandler)
+	for _, action := range pkt.Actions {
+		networkID, ok := droppedItemNetworkID(action)
+		if !ok {
+			continue
+		}
+		entry, ok := registry.Item(int16(networkID))
+		if !ok {
+			continue
+		}
+		if s.claimActionPermitted(
+			ClaimActionItemDrop,
+			claimActionData{position: position, typeID: entry.Name},
+		) {
+			continue
+		}
+		s.claimMessage(position, text.Colourf("<red>You cannot drop items inside this claim.</red>"))
+		ctx.Cancel()
 		return
 	}
-	h.handleClaimReleaseItem(s, pkt, ctx)
+}
+
+func droppedItemNetworkID(action protocol.InventoryAction) (int32, bool) {
+	if action.SourceType != protocol.InventoryActionSourceWorld {
+		return 0, false
+	}
+	networkID := action.NewItem.Stack.ItemType.NetworkID
+	if networkID == 0 {
+		networkID = action.OldItem.Stack.ItemType.NetworkID
+	}
+	return networkID, networkID != 0
 }
 
 // handleClaimUseItem ...
@@ -104,67 +174,78 @@ func (h *InventoryTransactionHandler) handleClaimUseItem(s *Session, pkt *packet
 		return
 	}
 
-	clientXUID := s.IdentityData().XUID
-
-	dat := s.Data()
-	pos := transactionData.Position
-	cl, ok := ClaimAt(s.claimFactory.All(), dat.Dimension(), pos.X(), pos.Z())
-	if !ok {
-		return
+	if transactionData.ActionType == protocol.UseItemActionClickBlock {
+		h.handleClaimClickBlock(s, transactionData, ctx)
 	}
-
-	if cl.ID == "" || // Invalid claim?
-		cl.OwnerXUID == "*" || // Admin claim.
-		cl.OwnerXUID == clientXUID ||
-		slices.Contains(cl.TrustedXUIDS, clientXUID) {
-		return
-	}
-
-	if h.checkClaimBlockInteraction(s, ctx, transactionData) {
-		return
-	}
-
-	h.checkClaimItemThrow(s, ctx, transactionData)
 }
 
-func (h *InventoryTransactionHandler) checkClaimBlockInteraction(s *Session, ctx *Context, td *protocol.UseItemTransactionData) bool {
-	if td.ActionType == protocol.UseItemActionClickBlock &&
-		td.TriggerType == protocol.UseItemActionClickAir {
-		if b, exists := world.BlockByRuntimeID(td.BlockRuntimeID); exists {
-			switch b.(type) {
-			case block.ItemFrame, block.Lectern, block.DecoratedPot:
-				s.Message(text.Colourf("<red>You cannot interact with block entities inside this claim.</red>"))
-				ctx.Cancel()
-				return true
-			}
-		}
-	}
-	return false
-}
-
-func (h *InventoryTransactionHandler) checkClaimItemThrow(s *Session, ctx *Context, td *protocol.UseItemTransactionData) {
-	heldItem := td.HeldItem.Stack.ItemType
-	if heldItem.NetworkID == 0 {
+func (*InventoryTransactionHandler) handleClaimClickBlock(
+	s *Session,
+	transactionData *protocol.UseItemTransactionData,
+	ctx *Context,
+) {
+	pos := blockPosToVec3(transactionData.BlockPosition)
+	b, found := blockByRuntimeID(transactionData.BlockRuntimeID, s.GameData().UseBlockNetworkIDHashes)
+	if !found {
 		return
 	}
+	typeID, _ := b.EncodeBlock()
 
 	registry := s.handlers[packet.IDItemRegistry].(*ItemRegistryHandler)
-	if registry.items == nil {
+	heldItem, heldItemFound := registry.Item(int16(transactionData.HeldItem.Stack.NetworkID))
+	if heldItemFound && (heldItem.Name == "minecraft:stick" || heldItem.Name == "minecraft:golden_shovel") {
 		return
 	}
 
-	entry, ok := registry.items[int16(heldItem.NetworkID)]
-	if !ok {
+	if transactionData.HeldItem.Stack.BlockRuntimeID != 0 {
+		placePos, validFace := offsetBlockPos(transactionData.BlockPosition, transactionData.BlockFace)
+		placedBlock, placedBlockFound := blockByRuntimeID(
+			uint32(transactionData.HeldItem.Stack.BlockRuntimeID),
+			s.GameData().UseBlockNetworkIDHashes,
+		)
+		if !validFace || !placedBlockFound {
+			return
+		}
+		placedTypeID, _ := placedBlock.EncodeBlock()
+		if s.claimActionPermitted(
+			ClaimActionBlockPlace,
+			claimActionData{position: blockPosToVec3(placePos), typeID: placedTypeID},
+		) {
+			return
+		}
+		s.claimMessage(pos, text.Colourf("<red>You cannot place blocks inside this claim.</red>"))
+		ctx.Cancel()
 		return
 	}
 
-	components, ok := entry.Data["components"].(map[string]any)
-	if !ok || components["minecraft:throwable"] == nil {
+	if s.claimActionPermitted(
+		ClaimActionBlockInteract,
+		claimActionData{position: pos, typeID: typeID},
+	) {
 		return
 	}
-
-	s.Message(text.Colourf("<red>You cannot throw items inside this claim.</red>"))
+	s.claimMessage(pos, text.Colourf("<red>You cannot interact with blocks inside this claim.</red>"))
 	ctx.Cancel()
+}
+
+func offsetBlockPos(pos protocol.BlockPos, face int32) (protocol.BlockPos, bool) {
+	switch face {
+	case 0:
+		pos[1]--
+	case 1:
+		pos[1]++
+	case 2:
+		pos[2]--
+	case 3:
+		pos[2]++
+	case 4:
+		pos[0]--
+	case 5:
+		pos[0]++
+	default:
+		return pos, false
+	}
+	return pos, true
 }
 
 // handleClaimUseItemEntity ...
@@ -174,86 +255,38 @@ func (h *InventoryTransactionHandler) handleClaimUseItemOnEntity(s *Session, pkt
 		return
 	}
 
-	clientXUID := s.IdentityData().XUID
-
-	dat := s.Data()
-	pos := transactionData.Position
-	cl, ok := ClaimAt(s.claimFactory.All(), dat.Dimension(), pos.X(), pos.Z())
-	if !ok {
+	entity, exists := s.entityFactory.ByRuntimeID(transactionData.TargetEntityRuntimeID)
+	if !exists {
 		return
 	}
 
-	if cl.ID == "" || // Invalid claim?
-		cl.OwnerXUID == "*" || // Admin claim.
-		cl.OwnerXUID == clientXUID ||
-		slices.Contains(cl.TrustedXUIDS, clientXUID) {
-		return
-	}
-	ent, ok := s.entityFactory.ByRuntimeID(transactionData.TargetEntityRuntimeID)
-	if !ok {
-		return
-	}
-
-	switch ent.ActorType() {
+	switch entity.ActorType() {
 	case "minecraft:armor_stand", "minecraft:painting":
-		s.Message(text.Colourf("<red>You cannot interact with block entities inside this claim.</red>"))
-		ctx.Cancel()
-	}
-}
-
-// handleClaimReleaseItem ...
-func (h *InventoryTransactionHandler) handleClaimReleaseItem(s *Session, pkt *packet.InventoryTransaction, ctx *Context) {
-	transactionData, ok := pkt.TransactionData.(*protocol.ReleaseItemTransactionData)
-	if !ok {
-		return
-	}
-
-	clientXUID := s.IdentityData().XUID
-
-	dat := s.Data()
-	pos := transactionData.HeadPosition.Sub(mgl32.Vec3{0, 1.62})
-	cl, ok := ClaimAt(s.claimFactory.All(), dat.Dimension(), pos.X(), pos.Z())
-	if !ok {
-		return
-	}
-
-	if cl.ID == "" || // Invalid claim?
-		cl.OwnerXUID == "*" || // Admin claim.
-		cl.OwnerXUID == clientXUID ||
-		slices.Contains(cl.TrustedXUIDS, clientXUID) {
-		return
-	}
-
-	s.Message(text.Colourf("<red>You cannot release items inside this claim.</red>"))
-	ctx.Cancel()
-}
-
-// claimDimensionToInt ...
-func claimDimensionToInt(dimension string) int32 {
-	switch dimension {
-	case "minecraft:overworld":
-		return 0
-	case "minecraft:nether":
-		return 1
-	case "minecraft:end":
-		return 2
 	default:
-		return -1
+		return
 	}
-}
+	entityPosition := entity.Position()
 
-// ClaimAt ...
-func ClaimAt(claims map[string]claim.PlayerClaim, dimension int32, x, z float32) (claim.PlayerClaim, bool) {
-	for _, c := range claims {
-		if claimDimensionToInt(c.Location.Dimension) == dimension {
-			minX := min(c.Location.Pos1.X, c.Location.Pos2.X)
-			maxX := max(c.Location.Pos1.X, c.Location.Pos2.X)
-			minZ := min(c.Location.Pos1.Z, c.Location.Pos2.Z)
-			maxZ := max(c.Location.Pos1.Z, c.Location.Pos2.Z)
-			if x >= minX && x <= maxX && z >= minZ && z <= maxZ {
-				return c, true
-			}
-		}
+	var action ClaimAction
+	var actionName string
+	switch transactionData.ActionType {
+	case protocol.UseItemOnEntityActionInteract:
+		action = ClaimActionEntityInteract
+		actionName = "interact with"
+	case protocol.UseItemOnEntityActionAttack:
+		action = ClaimActionEntityHurt
+		actionName = "hurt"
+	default:
+		return
 	}
-	return claim.PlayerClaim{}, false
+	permitted := s.claimActionPermitted(action, claimActionData{
+		position: entityPosition,
+		typeID:   entity.ActorType(),
+	})
+	if permitted {
+		return
+	}
+
+	s.claimMessage(entityPosition, text.Colourf("<red>You cannot %s entities inside this claim.</red>", actionName))
+	ctx.Cancel()
 }

--- a/gobds/session/handler_inventory_transaction.go
+++ b/gobds/session/handler_inventory_transaction.go
@@ -160,9 +160,9 @@ func droppedItemNetworkID(action protocol.InventoryAction) (int32, bool) {
 	if action.SourceType != protocol.InventoryActionSourceWorld {
 		return 0, false
 	}
-	networkID := action.NewItem.Stack.ItemType.NetworkID
+	networkID := action.NewItem.Stack.NetworkID
 	if networkID == 0 {
-		networkID = action.OldItem.Stack.ItemType.NetworkID
+		networkID = action.OldItem.Stack.NetworkID
 	}
 	return networkID, networkID != 0
 }

--- a/gobds/session/handler_inventory_transaction_test.go
+++ b/gobds/session/handler_inventory_transaction_test.go
@@ -1,0 +1,115 @@
+package session
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/sandertv/gophertunnel/minecraft/protocol"
+	"github.com/sandertv/gophertunnel/minecraft/protocol/packet"
+)
+
+func TestDroppedItemNetworkIDOnlyAcceptsWorldActions(t *testing.T) {
+	item := protocol.ItemInstance{
+		Stack: protocol.ItemStack{ItemType: protocol.ItemType{NetworkID: 42}},
+	}
+	if id, ok := droppedItemNetworkID(protocol.InventoryAction{
+		SourceType: protocol.InventoryActionSourceWorld,
+		NewItem:    item,
+	}); !ok || id != 42 {
+		t.Fatalf("world drop returned id=%d, ok=%v", id, ok)
+	}
+	if id, ok := droppedItemNetworkID(protocol.InventoryAction{
+		SourceType: protocol.InventoryActionSourceContainer,
+		NewItem:    item,
+	}); ok || id != 0 {
+		t.Fatalf("container action treated as drop: id=%d, ok=%v", id, ok)
+	}
+	if id, ok := droppedItemNetworkID(protocol.InventoryAction{
+		SourceType: protocol.InventoryActionSourceWorld,
+	}); ok || id != 0 {
+		t.Fatalf("empty world action treated as drop: id=%d, ok=%v", id, ok)
+	}
+}
+
+func TestOffsetBlockPosUsesBedrockFaceOrder(t *testing.T) {
+	start := protocol.BlockPos{10, 20, 30}
+	tests := []struct {
+		face int32
+		want protocol.BlockPos
+	}{
+		{face: 0, want: protocol.BlockPos{10, 19, 30}},
+		{face: 1, want: protocol.BlockPos{10, 21, 30}},
+		{face: 2, want: protocol.BlockPos{10, 20, 29}},
+		{face: 3, want: protocol.BlockPos{10, 20, 31}},
+		{face: 4, want: protocol.BlockPos{9, 20, 30}},
+		{face: 5, want: protocol.BlockPos{11, 20, 30}},
+	}
+	for _, test := range tests {
+		got, ok := offsetBlockPos(start, test.face)
+		if !ok || got != test.want {
+			t.Fatalf("face %d returned %v, ok=%v; want %v", test.face, got, ok, test.want)
+		}
+	}
+	if _, ok := offsetBlockPos(start, 6); ok {
+		t.Fatal("unknown face must fail open")
+	}
+}
+
+func TestItemStackRequestActionBounds(t *testing.T) {
+	config := DefaultTrafficConfig()
+	dropTests := []struct {
+		name string
+		pkt  packet.ItemStackRequest
+	}{
+		{name: "empty"},
+		{
+			name: "empty actions",
+			pkt: packet.ItemStackRequest{Requests: []protocol.ItemStackRequest{
+				{RequestID: 1},
+			}},
+		},
+	}
+	for _, test := range dropTests {
+		t.Run(test.name, func(t *testing.T) {
+			drop, err := validateItemStackRequest(&test.pkt, config)
+			if err != nil || !drop {
+				t.Fatalf("expected quiet malformed drop, got drop=%v err=%v", drop, err)
+			}
+		})
+	}
+	disconnectTests := []struct {
+		name string
+		pkt  packet.ItemStackRequest
+	}{
+		{
+			name: "too many requests",
+			pkt: packet.ItemStackRequest{Requests: make(
+				[]protocol.ItemStackRequest,
+				config.MaxStackRequests+1,
+			)},
+		},
+		{
+			name: "too many actions",
+			pkt: packet.ItemStackRequest{Requests: []protocol.ItemStackRequest{{
+				RequestID: 1,
+				Actions:   make([]protocol.StackRequestAction, config.MaxStackActions+1),
+			}}},
+		},
+	}
+	for _, test := range disconnectTests {
+		t.Run(test.name, func(t *testing.T) {
+			var malformed malformedPacketError
+			drop, err := validateItemStackRequest(&test.pkt, config)
+			if drop || !errors.As(err, &malformed) {
+				t.Fatalf("expected malformed error, got %v", err)
+			}
+		})
+	}
+	valid := packet.ItemStackRequest{Requests: []protocol.ItemStackRequest{{
+		RequestID: 1,
+		Actions:   []protocol.StackRequestAction{nil},
+	}}}
+	if drop, err := validateItemStackRequest(&valid, config); err != nil || drop {
+		t.Fatalf("valid bounded request rejected: drop=%v err=%v", drop, err)
+	}
+}

--- a/gobds/session/handler_item_registry.go
+++ b/gobds/session/handler_item_registry.go
@@ -1,6 +1,8 @@
 package session
 
 import (
+	"sync"
+
 	"github.com/sandertv/gophertunnel/minecraft/protocol"
 	"github.com/sandertv/gophertunnel/minecraft/protocol/packet"
 )
@@ -8,15 +10,29 @@ import (
 // ItemRegistryHandler ...
 type ItemRegistryHandler struct {
 	items map[int16]protocol.ItemEntry
+	mu    sync.RWMutex
 }
 
 // Handle ...
-func (h *ItemRegistryHandler) Handle(_ *Session, pk packet.Packet, _ *Context) error {
+func (h *ItemRegistryHandler) Handle(s *Session, pk packet.Packet, ctx *Context) error {
+	if ctx.Val() != s.server {
+		return nil
+	}
 	pkt := pk.(*packet.ItemRegistry)
 	items := make(map[int16]protocol.ItemEntry)
 	for _, item := range pkt.Items {
 		items[item.RuntimeID] = item
 	}
+	h.mu.Lock()
 	h.items = items
+	h.mu.Unlock()
 	return nil
+}
+
+// Item returns the item registry entry for a runtime ID.
+func (h *ItemRegistryHandler) Item(runtimeID int16) (protocol.ItemEntry, bool) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	entry, ok := h.items[runtimeID]
+	return entry, ok
 }

--- a/gobds/session/handler_item_stack_request.go
+++ b/gobds/session/handler_item_stack_request.go
@@ -11,9 +11,25 @@ type ItemStackRequestHandler struct{}
 // Handle ...
 func (*ItemStackRequestHandler) Handle(s *Session, pk packet.Packet, ctx *Context) error {
 	pkt := pk.(*packet.ItemStackRequest)
+	if ctx.Val() == s.client {
+		drop, err := validateItemStackRequest(pkt, s.traffic.config)
+		if drop {
+			s.traffic.malformed(trafficStack)
+			ctx.Cancel()
+			return nil
+		}
+		if err != nil {
+			s.traffic.malformed(trafficStack)
+			return err
+		}
+		if !s.traffic.allow(trafficStack) {
+			ctx.Cancel()
+			return nil
+		}
+	}
 	for _, request := range pkt.Requests {
-		for _, action := range request.Actions {
-			switch action := action.(type) {
+		for _, requestAction := range request.Actions {
+			switch action := requestAction.(type) {
 			case *protocol.PlaceStackRequestAction:
 				if action.Source.Container.ContainerID == protocol.ContainerDynamic ||
 					action.Destination.Container.ContainerID == protocol.ContainerDynamic {
@@ -40,4 +56,27 @@ func (*ItemStackRequestHandler) Handle(s *Session, pk packet.Packet, ctx *Contex
 		}
 	}
 	return nil
+}
+
+func validateItemStackRequest(pkt *packet.ItemStackRequest, config TrafficConfig) (drop bool, err error) {
+	if len(pkt.Requests) == 0 {
+		return true, nil
+	}
+	if len(pkt.Requests) > config.MaxStackRequests {
+		return false, malformedPacketError{reason: "item stack packet has too many requests"}
+	}
+	totalActions := 0
+	for _, request := range pkt.Requests {
+		if len(request.Actions) == 0 {
+			return true, nil
+		}
+		if len(request.Actions) > config.MaxStackActions {
+			return false, malformedPacketError{reason: "item stack request has too many actions"}
+		}
+		totalActions += len(request.Actions)
+		if totalActions > config.MaxTotalStackActions {
+			return false, malformedPacketError{reason: "item stack packet has too many total actions"}
+		}
+	}
+	return false, nil
 }

--- a/gobds/session/handler_modal_form_response.go
+++ b/gobds/session/handler_modal_form_response.go
@@ -1,0 +1,55 @@
+package session
+
+import (
+	"bytes"
+	"encoding/json"
+
+	"github.com/sandertv/gophertunnel/minecraft/protocol/packet"
+)
+
+// ModalFormResponseHandler bounds and rate-checks client form responses.
+type ModalFormResponseHandler struct{}
+
+// Handle validates a response before forwarding it to BDS.
+func (*ModalFormResponseHandler) Handle(s *Session, pk packet.Packet, ctx *Context) error {
+	if ctx.Val() != s.client {
+		return nil
+	}
+	pkt := pk.(*packet.ModalFormResponse)
+	response, present := pkt.ResponseData.Value()
+	if present {
+		if err := validateFormResponse(response, s.traffic.config); err != nil {
+			s.traffic.malformed(trafficForm)
+			return err
+		}
+	}
+	if _, cancelled := pkt.CancelReason.Value(); !present && !cancelled {
+		s.traffic.malformed(trafficForm)
+		return malformedPacketError{reason: "form response has no response or cancellation"}
+	}
+	if !s.traffic.allow(trafficForm) {
+		ctx.Cancel()
+	}
+	return nil
+}
+
+func validateFormResponse(response []byte, config TrafficConfig) error {
+	if len(response) > config.MaxFormResponseBytes {
+		return malformedPacketError{reason: "form response exceeds maximum length"}
+	}
+	response = bytes.TrimSpace(response)
+	if len(response) == 0 || !json.Valid(response) {
+		return malformedPacketError{reason: "form response is not valid JSON"}
+	}
+	if response[0] != '[' {
+		return nil
+	}
+	var values []json.RawMessage
+	if err := json.Unmarshal(response, &values); err != nil {
+		return malformedPacketError{reason: "form response array is invalid"}
+	}
+	if len(values) > config.MaxFormResponseValues {
+		return malformedPacketError{reason: "form response has too many values"}
+	}
+	return nil
+}

--- a/gobds/session/handler_move_actor.go
+++ b/gobds/session/handler_move_actor.go
@@ -1,0 +1,26 @@
+package session
+
+import "github.com/sandertv/gophertunnel/minecraft/protocol/packet"
+
+// MoveActorHandler keeps tracked entity positions current.
+type MoveActorHandler struct{}
+
+// Handle ...
+func (*MoveActorHandler) Handle(s *Session, pk packet.Packet, ctx *Context) error {
+	if ctx.Val() != s.server {
+		return nil
+	}
+	switch pkt := pk.(type) {
+	case *packet.MoveActorAbsolute:
+		s.entityFactory.UpdatePosition(pkt.EntityRuntimeID, pkt.Position, true, true, true)
+	case *packet.MoveActorDelta:
+		s.entityFactory.UpdatePosition(
+			pkt.EntityRuntimeID,
+			pkt.Position,
+			pkt.Flags&packet.MoveActorDeltaFlagHasX != 0,
+			pkt.Flags&packet.MoveActorDeltaFlagHasY != 0,
+			pkt.Flags&packet.MoveActorDeltaFlagHasZ != 0,
+		)
+	}
+	return nil
+}

--- a/gobds/session/handler_player_auth_input.go
+++ b/gobds/session/handler_player_auth_input.go
@@ -1,7 +1,7 @@
 package session
 
 import (
-	"slices"
+	"time"
 
 	"github.com/sandertv/gophertunnel/minecraft/protocol"
 	"github.com/sandertv/gophertunnel/minecraft/protocol/packet"
@@ -17,55 +17,108 @@ func NewPlayerAuthInputHandler() *PlayerAuthInputHandler {
 }
 
 // Handle ...
-func (h *PlayerAuthInputHandler) Handle(s *Session, pk packet.Packet, ctx *Context) error {
+func (h *PlayerAuthInputHandler) Handle(s *Session, pk packet.Packet, _ *Context) (err error) {
+	if s.claimFactory != nil {
+		s.claimFactory.Metrics().Packet()
+		start := time.Now()
+		defer func() { s.claimFactory.Metrics().Latency(time.Since(start)) }()
+	}
 	pkt := pk.(*packet.PlayerAuthInput)
+	originalActions := pkt.BlockActions
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			pkt.BlockActions = originalActions
+			s.log.Error("claim player auth input failed open", "error", recovered)
+		}
+	}()
 
 	if pkt.Tick%20 == 0 {
 		s.ForwardPing()
-		if s.afkTimer != nil {
-			s.TouchMovement(pkt.Position, pkt.Yaw, pkt.Pitch)
-		}
+		s.TouchMovement(pkt.Position, pkt.Yaw, pkt.Pitch)
 	}
 
-	h.handleWorldBorder(s, pkt, ctx)
+	h.handleWorldInteractions(s, pkt)
 	return nil
 }
 
-// handleWorldBorder ...
-func (h *PlayerAuthInputHandler) handleWorldBorder(s *Session, pkt *packet.PlayerAuthInput, ctx *Context) {
+// handleWorldInteractions ...
+func (h *PlayerAuthInputHandler) handleWorldInteractions(s *Session, pkt *packet.PlayerAuthInput) {
 	clientData := s.Data()
-	clientXUID := s.IdentityData().XUID
-	for i, action := range pkt.BlockActions {
-		if action.Action == protocol.PlayerActionCrackBreak {
-			continue
-		}
-
-		blockPosition := action.BlockPos
-		if action.Action == protocol.PlayerActionStopBreak && (i == 0 || i == 1) && len(pkt.BlockActions) > 1 {
-			switch i {
-			case 0:
-				blockPosition = pkt.BlockActions[i+1].BlockPos
-			default:
-				blockPosition = pkt.BlockActions[i-1].BlockPos
-			}
-		}
-
+	denied := filterPlayerAuthInputPacket(pkt, func(blockAction protocol.PlayerBlockAction) bool {
+		blockPosition := blockAction.BlockPos
 		if s.border != nil && !s.border.PositionInside(blockPosition.X(), blockPosition.Z()) {
-			ctx.Cancel()
+			return true
+		}
+		return !s.claimActionPermitted(ClaimActionBlockBreak, blockPosToVec3(blockPosition))
+	})
+	if clientData.GameMode() != packet.GameTypeCreative {
+		return
+	}
+	for _, blockPosition := range denied {
+		chunkPos := protocol.ChunkPos{blockPosition.X() >> 4, blockPosition.Z() >> 4}
+		correction, ok := correctiveLevelChunk(
+			chunkPos,
+			clientData.Dimension(),
+			s.GameData().Dimensions,
+		)
+		if !ok {
+			s.claimFactory.Metrics().Correction(false)
 			continue
 		}
+		if !s.allowCorrective(chunkPos, time.Second) {
+			s.claimFactory.Metrics().Correction(false)
+			continue
+		}
+		s.WriteToClient(correction)
+		s.claimFactory.Metrics().Correction(true)
+	}
+}
 
-		claim, exists := ClaimAt(s.claimFactory.All(), clientData.Dimension(), float32(blockPosition.X()), float32(blockPosition.Z()))
-		if !exists {
-			continue
-		}
-		if claim.ID == "" || // Invalid claim?
-			claim.OwnerXUID == "*" || // Admin claim.
-			claim.OwnerXUID == clientXUID ||
-			slices.Contains(claim.TrustedXUIDS, clientXUID) {
-			continue
-		}
+func correctiveLevelChunk(
+	chunkPos protocol.ChunkPos,
+	dimension int32,
+	definitions []protocol.DimensionDefinition,
+) (*packet.LevelChunk, bool) {
+	dimensionRange, ok := dimensionRangeByID(dimension, definitions)
+	if !ok || dimensionRange.Height() <= 0 {
+		return nil, false
+	}
+	subChunkCount := (dimensionRange.Height() + 15) >> 4
+	if subChunkCount > int(^uint16(0)) {
+		return nil, false
+	}
+	return &packet.LevelChunk{
+		Position:        chunkPos,
+		Dimension:       dimension,
+		HighestSubChunk: uint16(subChunkCount),
+		SubChunkCount:   protocol.SubChunkRequestModeLimited,
+	}, true
+}
 
-		ctx.Cancel()
+func filterPlayerAuthInputPacket(
+	pkt *packet.PlayerAuthInput,
+	denied func(protocol.PlayerBlockAction) bool,
+) []protocol.BlockPos {
+	filtered := make([]protocol.PlayerBlockAction, 0, len(pkt.BlockActions))
+	deniedPositions := make([]protocol.BlockPos, 0)
+	for _, action := range pkt.BlockActions {
+		if !isFilterableBlockAction(action.Action) || !denied(action) {
+			filtered = append(filtered, action)
+			continue
+		}
+		deniedPositions = append(deniedPositions, action.BlockPos)
+	}
+	pkt.BlockActions = filtered
+	return deniedPositions
+}
+
+func isFilterableBlockAction(action int32) bool {
+	switch action {
+	case protocol.PlayerActionStartBreak,
+		protocol.PlayerActionPredictDestroyBlock,
+		protocol.PlayerActionContinueDestroyBlock:
+		return true
+	default:
+		return false
 	}
 }

--- a/gobds/session/handler_player_auth_input_test.go
+++ b/gobds/session/handler_player_auth_input_test.go
@@ -1,0 +1,73 @@
+package session
+
+import (
+	"testing"
+
+	"github.com/go-gl/mathgl/mgl32"
+	"github.com/sandertv/gophertunnel/minecraft/protocol"
+	"github.com/sandertv/gophertunnel/minecraft/protocol/packet"
+)
+
+func TestPlayerAuthInputFiltersOnlyDeniedBlockActions(t *testing.T) {
+	denied := protocol.PlayerBlockAction{
+		Action:   protocol.PlayerActionStartBreak,
+		BlockPos: protocol.BlockPos{1, 2, 3},
+	}
+	allowed := protocol.PlayerBlockAction{
+		Action:   protocol.PlayerActionContinueDestroyBlock,
+		BlockPos: protocol.BlockPos{4, 5, 6},
+	}
+	unsupported := protocol.PlayerBlockAction{
+		Action:   protocol.PlayerActionCrackBreak,
+		BlockPos: protocol.BlockPos{7, 8, 9},
+	}
+	pkt := &packet.PlayerAuthInput{
+		Position:               mgl32.Vec3{10, 20, 30},
+		MoveVector:             mgl32.Vec2{0.5, -0.5},
+		VehicleRotation:        mgl32.Vec2{40, 50},
+		ClientPredictedVehicle: 99,
+		BlockActions:           []protocol.PlayerBlockAction{denied, allowed, unsupported},
+	}
+
+	deniedPositions := filterPlayerAuthInputPacket(pkt, func(action protocol.PlayerBlockAction) bool {
+		return action.BlockPos == denied.BlockPos
+	})
+
+	if len(pkt.BlockActions) != 2 || pkt.BlockActions[0] != allowed || pkt.BlockActions[1] != unsupported {
+		t.Fatalf("unexpected forwarded actions: %+v", pkt.BlockActions)
+	}
+	if len(deniedPositions) != 1 || deniedPositions[0] != denied.BlockPos {
+		t.Fatalf("unexpected denied positions: %+v", deniedPositions)
+	}
+	if pkt.Position != (mgl32.Vec3{10, 20, 30}) ||
+		pkt.MoveVector != (mgl32.Vec2{0.5, -0.5}) ||
+		pkt.VehicleRotation != (mgl32.Vec2{40, 50}) ||
+		pkt.ClientPredictedVehicle != 99 {
+		t.Fatal("movement or vehicle input changed while filtering block actions")
+	}
+}
+
+func TestCorrectiveLevelChunkUsesCustomDimensionFields(t *testing.T) {
+	definitions := []protocol.DimensionDefinition{{
+		Name:          "pokeb:battle_arena",
+		Range:         [2]int32{-64, 320},
+		DimensionType: 1000,
+	}}
+	chunkPos := protocol.ChunkPos{12, -7}
+	correction, ok := correctiveLevelChunk(chunkPos, 1000, definitions)
+	if !ok {
+		t.Fatal("custom dimension correction was not built")
+	}
+	if correction.Position != chunkPos ||
+		correction.Dimension != 1000 ||
+		correction.HighestSubChunk != 24 ||
+		correction.SubChunkCount != protocol.SubChunkRequestModeLimited {
+		t.Fatalf("unexpected custom dimension correction: %+v", correction)
+	}
+}
+
+func TestCorrectiveLevelChunkFailsOpenForUnknownDimension(t *testing.T) {
+	if correction, ok := correctiveLevelChunk(protocol.ChunkPos{}, 1000, nil); ok || correction != nil {
+		t.Fatalf("unknown dimension produced correction: %+v", correction)
+	}
+}

--- a/gobds/session/handler_remove_actor.go
+++ b/gobds/session/handler_remove_actor.go
@@ -8,8 +8,11 @@ import (
 type RemoveActorHandler struct{}
 
 // Handle ...
-func (*RemoveActorHandler) Handle(s *Session, pk packet.Packet, _ *Context) error {
+func (*RemoveActorHandler) Handle(s *Session, pk packet.Packet, ctx *Context) error {
+	if ctx.Val() != s.server {
+		return nil
+	}
 	pkt := pk.(*packet.RemoveActor)
-	s.entityFactory.RemoveFromRuntimeID(uint64(pkt.EntityUniqueID))
+	s.entityFactory.RemoveFromUniqueID(pkt.EntityUniqueID)
 	return nil
 }

--- a/gobds/session/handler_set_player_game_type.go
+++ b/gobds/session/handler_set_player_game_type.go
@@ -1,0 +1,16 @@
+package session
+
+import "github.com/sandertv/gophertunnel/minecraft/protocol/packet"
+
+// SetPlayerGameTypeHandler ...
+type SetPlayerGameTypeHandler struct{}
+
+// Handle ...
+func (*SetPlayerGameTypeHandler) Handle(s *Session, pk packet.Packet, ctx *Context) error {
+	pkt := pk.(*packet.SetPlayerGameType)
+	if ctx.Val() != s.server {
+		return nil
+	}
+	s.Data().SetGameMode(pkt.GameType)
+	return nil
+}

--- a/gobds/session/handler_sub_chunk.go
+++ b/gobds/session/handler_sub_chunk.go
@@ -37,65 +37,87 @@ func (*SubChunkHandler) Handle(s *Session, pk packet.Packet, ctx *Context) (err 
 	s.Data().SetDimension(pkt.Dimension)
 
 	dimensions := s.GameData().Dimensions
-	var snapshot *claim.Snapshot
-	var snapshotStatus claim.QueryStatus
-	var dimension string
-	var dimensionFound bool
-	if s.claimDenyRendering && s.claimFactory != nil {
-		snapshot, snapshotStatus = s.claimFactory.Snapshot(time.Now())
-		dimension, dimensionFound = claimDimensionFromInt(pkt.Dimension, dimensions)
-		if snapshotStatus != claim.QueryReady {
-			s.claimFactory.Metrics().Reason(snapshotStatus)
-		}
-		if !dimensionFound {
-			s.claimFactory.Metrics().Reason(claim.QueryUnknownDimension)
-		}
-	}
+	snapshot, snapshotStatus, dimension, dimensionFound := resolveClaimSubChunkContext(s, pkt.Dimension, dimensions)
+	dimensionRange, rangeFound := dimensionRangeByID(pkt.Dimension, dimensions)
 
 	entries := make([]protocol.SubChunkEntry, 0, len(pkt.SubChunkEntries))
 	for _, entry := range pkt.SubChunkEntries {
-		chunkPos := protocol.ChunkPos{
-			pkt.Position.X() + int32(entry.Offset[0]),
-			pkt.Position.Z() + int32(entry.Offset[2]),
-		}
-
-		if s.border != nil && !s.border.ChunkInside(chunkPos) {
-			continue
-		}
-
-		if !s.claimDenyRendering || s.claimFactory == nil {
-			entries = append(entries, entry)
-			continue
-		}
-
-		dimensionRange, rangeFound := dimensionRangeByID(pkt.Dimension, dimensions)
-		// GoBDS disables the backend blob cache, so successful entries normally
-		// contain the sub-chunk bytes inline. Leave cached entries untouched if
-		// that invariant changes.
-		if entry.Result != protocol.SubChunkResultSuccess || !rangeFound || !dimensionFound ||
-			snapshotStatus != claim.QueryReady || pkt.CacheEnabled {
-			entries = append(entries, entry)
-			continue
-		}
-		chunkX := float32(chunkPos.X() << 4)
-		chunkZ := float32(chunkPos.Z() << 4)
-		candidates := snapshot.Candidates(dimension, chunkX, chunkZ)
-		s.claimFactory.Metrics().Candidates(len(candidates))
-
-		entries = append(entries, applyClaimDenyBlocks(
-			s,
-			pkt,
-			entry,
-			chunkPos,
-			dimensionRange,
-			candidates,
-			denyBlockRuntimeID(s.GameData().UseBlockNetworkIDHashes),
-			ClaimActor{XUID: s.IdentityData().XUID, Operator: s.Data().Operator()},
-		))
+		entries = append(entries, filterSubChunkEntry(
+			s, pkt, entry, snapshot, snapshotStatus,
+			dimension, dimensionFound, dimensionRange, rangeFound,
+		)...)
 	}
 
 	pkt.SubChunkEntries = entries
 	return nil
+}
+
+func resolveClaimSubChunkContext(
+	s *Session,
+	dimensionID int32,
+	dimensions []protocol.DimensionDefinition,
+) (*claim.Snapshot, claim.QueryStatus, string, bool) {
+	if !s.claimDenyRendering || s.claimFactory == nil {
+		return nil, 0, "", false
+	}
+	snapshot, snapshotStatus := s.claimFactory.Snapshot(time.Now())
+	dimension, dimensionFound := claimDimensionFromInt(dimensionID, dimensions)
+	if snapshotStatus != claim.QueryReady {
+		s.claimFactory.Metrics().Reason(snapshotStatus)
+	}
+	if !dimensionFound {
+		s.claimFactory.Metrics().Reason(claim.QueryUnknownDimension)
+	}
+	return snapshot, snapshotStatus, dimension, dimensionFound
+}
+
+// filterSubChunkEntry returns zero or one entries for the packet rewrite.
+func filterSubChunkEntry(
+	s *Session,
+	pkt *packet.SubChunk,
+	entry protocol.SubChunkEntry,
+	snapshot *claim.Snapshot,
+	snapshotStatus claim.QueryStatus,
+	dimension string,
+	dimensionFound bool,
+	dimensionRange cube.Range,
+	rangeFound bool,
+) []protocol.SubChunkEntry {
+	chunkPos := protocol.ChunkPos{
+		pkt.Position.X() + int32(entry.Offset[0]),
+		pkt.Position.Z() + int32(entry.Offset[2]),
+	}
+
+	if s.border != nil && !s.border.ChunkInside(chunkPos) {
+		return nil
+	}
+
+	if !s.claimDenyRendering || s.claimFactory == nil {
+		return []protocol.SubChunkEntry{entry}
+	}
+
+	// GoBDS disables the backend blob cache, so successful entries normally
+	// contain the sub-chunk bytes inline. Leave cached entries untouched if
+	// that invariant changes.
+	if entry.Result != protocol.SubChunkResultSuccess || !rangeFound || !dimensionFound ||
+		snapshotStatus != claim.QueryReady || pkt.CacheEnabled {
+		return []protocol.SubChunkEntry{entry}
+	}
+	chunkX := float32(chunkPos.X() << 4)
+	chunkZ := float32(chunkPos.Z() << 4)
+	candidates := snapshot.Candidates(dimension, chunkX, chunkZ)
+	s.claimFactory.Metrics().Candidates(len(candidates))
+
+	return []protocol.SubChunkEntry{applyClaimDenyBlocks(
+		s,
+		pkt,
+		entry,
+		chunkPos,
+		dimensionRange,
+		candidates,
+		denyBlockRuntimeID(s.GameData().UseBlockNetworkIDHashes),
+		ClaimActor{XUID: s.IdentityData().XUID, Operator: s.Data().Operator()},
+	)}
 }
 
 func applyClaimDenyBlocks(

--- a/gobds/session/handler_sub_chunk.go
+++ b/gobds/session/handler_sub_chunk.go
@@ -1,29 +1,172 @@
 package session
 
 import (
-	"slices"
+	"bytes"
+	"time"
+	_ "unsafe"
 
+	"github.com/df-mc/dragonfly/server/block/cube"
+	"github.com/df-mc/dragonfly/server/world"
+	"github.com/df-mc/dragonfly/server/world/chunk"
 	"github.com/sandertv/gophertunnel/minecraft/protocol"
 	"github.com/sandertv/gophertunnel/minecraft/protocol/packet"
+	"github.com/smell-of-curry/gobds/gobds/claim"
 )
 
 // SubChunkHandler ...
 type SubChunkHandler struct{}
 
 // Handle ...
-func (*SubChunkHandler) Handle(s *Session, pk packet.Packet, _ *Context) error {
-	pkt := pk.(*packet.SubChunk)
-	s.Data().SetDimension(pkt.Dimension)
-
-	if s.border == nil {
+func (*SubChunkHandler) Handle(s *Session, pk packet.Packet, ctx *Context) (err error) {
+	if s.claimFactory != nil {
+		s.claimFactory.Metrics().Packet()
+		start := time.Now()
+		defer func() { s.claimFactory.Metrics().Latency(time.Since(start)) }()
+	}
+	if ctx.Val() != s.server {
 		return nil
 	}
+	pkt := pk.(*packet.SubChunk)
+	originalEntries := pkt.SubChunkEntries
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			pkt.SubChunkEntries = originalEntries
+			s.log.Error("claim subchunk handler failed open", "error", recovered)
+		}
+	}()
+	s.Data().SetDimension(pkt.Dimension)
 
-	pkt.SubChunkEntries = slices.DeleteFunc(pkt.SubChunkEntries, func(entry protocol.SubChunkEntry) bool {
-		return !s.border.ChunkInside(protocol.ChunkPos{
+	dimensions := s.GameData().Dimensions
+	var snapshot *claim.Snapshot
+	var snapshotStatus claim.QueryStatus
+	var dimension string
+	var dimensionFound bool
+	if s.claimDenyRendering && s.claimFactory != nil {
+		snapshot, snapshotStatus = s.claimFactory.Snapshot(time.Now())
+		dimension, dimensionFound = claimDimensionFromInt(pkt.Dimension, dimensions)
+		if snapshotStatus != claim.QueryReady {
+			s.claimFactory.Metrics().Reason(snapshotStatus)
+		}
+		if !dimensionFound {
+			s.claimFactory.Metrics().Reason(claim.QueryUnknownDimension)
+		}
+	}
+
+	entries := make([]protocol.SubChunkEntry, 0, len(pkt.SubChunkEntries))
+	for _, entry := range pkt.SubChunkEntries {
+		chunkPos := protocol.ChunkPos{
 			pkt.Position.X() + int32(entry.Offset[0]),
 			pkt.Position.Z() + int32(entry.Offset[2]),
-		})
-	})
+		}
+
+		if s.border != nil && !s.border.ChunkInside(chunkPos) {
+			continue
+		}
+
+		if !s.claimDenyRendering || s.claimFactory == nil {
+			entries = append(entries, entry)
+			continue
+		}
+
+		dimensionRange, rangeFound := dimensionRangeByID(pkt.Dimension, dimensions)
+		// GoBDS disables the backend blob cache, so successful entries normally
+		// contain the sub-chunk bytes inline. Leave cached entries untouched if
+		// that invariant changes.
+		if entry.Result != protocol.SubChunkResultSuccess || !rangeFound || !dimensionFound ||
+			snapshotStatus != claim.QueryReady || pkt.CacheEnabled {
+			entries = append(entries, entry)
+			continue
+		}
+		chunkX := float32(chunkPos.X() << 4)
+		chunkZ := float32(chunkPos.Z() << 4)
+		candidates := snapshot.Candidates(dimension, chunkX, chunkZ)
+		s.claimFactory.Metrics().Candidates(len(candidates))
+
+		entries = append(entries, applyClaimDenyBlocks(
+			s,
+			pkt,
+			entry,
+			chunkPos,
+			dimensionRange,
+			candidates,
+			denyBlockRuntimeID(s.GameData().UseBlockNetworkIDHashes),
+			ClaimActor{XUID: s.IdentityData().XUID, Operator: s.Data().Operator()},
+		))
+	}
+
+	pkt.SubChunkEntries = entries
 	return nil
 }
+
+func applyClaimDenyBlocks(
+	s *Session,
+	pkt *packet.SubChunk,
+	entry protocol.SubChunkEntry,
+	chunkPos protocol.ChunkPos,
+	dimensionRange cube.Range,
+	claims []*claim.PlayerClaim,
+	denyID uint32,
+	actor ClaimActor,
+) protocol.SubChunkEntry {
+	sectionY := pkt.Position.Y() + int32(entry.Offset[1])
+	if sectionY != int32(dimensionRange.Min()>>4) {
+		return entry
+	}
+	if len(claims) == 0 {
+		return entry
+	}
+
+	virtualChunk := chunk.New(world.DefaultBlockRegistry, dimensionRange)
+	var index byte
+	buf := bytes.NewBuffer(entry.RawPayload)
+	decodedEntry, err := decodeSubChunk(buf, virtualChunk, &index, chunk.NetworkEncoding)
+	if err != nil {
+		s.claimFactory.Metrics().SubchunkError()
+		s.log.Error("decode subchunk entry", "error", err)
+		return entry
+	}
+	s.claimFactory.Metrics().SubchunkDecoded()
+	if int(index) >= len(virtualChunk.Sub()) {
+		s.claimFactory.Metrics().SubchunkError()
+		s.log.Error("decode subchunk entry", "error", "subchunk index outside dimension range", "index", index)
+		return entry
+	}
+	blockEntityPayload := bytes.Clone(buf.Bytes())
+
+	var modified bool
+	for z := uint8(0); z < 16; z++ {
+		for x := uint8(0); x < 16; x++ {
+			blockPos := protocol.BlockPos{
+				(chunkPos.X() << 4) + int32(x), 0, (chunkPos.Z() << 4) + int32(z),
+			}
+			position := blockPosToVec3(blockPos)
+			matched, ambiguous := singleClaimAt(claims, position.X(), position.Z())
+			if ambiguous {
+				s.claimFactory.Metrics().Reason(claim.QueryOverlap)
+			}
+			denied := !ambiguous && matched != nil &&
+				!ClaimActionPermitted(*matched, actor, ClaimActionRender, position)
+			s.claimFactory.Metrics().Action(uint8(ClaimActionRender), !denied)
+			if !denied {
+				continue
+			}
+			decodedEntry.SetBlock(x, 0, z, 0, denyID)
+			modified = true
+		}
+	}
+	if !modified {
+		return entry
+	}
+	s.claimFactory.Metrics().SubchunkModified()
+	virtualChunk.Sub()[index] = decodedEntry
+	entry.RawPayload = append(
+		chunk.EncodeSubChunk(virtualChunk, chunk.NetworkEncoding, int(index)),
+		blockEntityPayload...,
+	)
+	return entry
+}
+
+// decodeSubChunk links Dragonfly's unexported single-subchunk decoder.
+//
+//go:linkname decodeSubChunk github.com/df-mc/dragonfly/server/world/chunk.decodeSubChunk
+func decodeSubChunk(buf *bytes.Buffer, c *chunk.Chunk, index *byte, e chunk.Encoding) (*chunk.SubChunk, error)

--- a/gobds/session/handler_text.go
+++ b/gobds/session/handler_text.go
@@ -35,8 +35,30 @@ func SetCommandPath(path string) {
 func (*TextHandler) Handle(s *Session, pk packet.Packet, ctx *Context) error {
 	pkt := pk.(*packet.Text)
 
-	// ensuring that only server packets are processed
-	if pkt.TextType != packet.TextTypeObject || ctx.Val() != s.server {
+	if ctx.Val() == s.client {
+		if len(pkt.Message) > s.traffic.config.MaxTextBytes || len(pkt.SourceName) > 256 ||
+			len(pkt.Parameters) > 64 {
+			s.traffic.malformed(trafficChat)
+			return malformedPacketError{reason: "text payload exceeds maximum length"}
+		}
+		for _, parameter := range pkt.Parameters {
+			if len(parameter) > s.traffic.config.MaxTextBytes {
+				s.traffic.malformed(trafficChat)
+				return malformedPacketError{reason: "text parameter exceeds maximum length"}
+			}
+		}
+		if strings.TrimSpace(pkt.Message) == "" {
+			s.traffic.malformed(trafficChat)
+			ctx.Cancel()
+			return nil
+		}
+		if !s.traffic.allow(trafficChat) {
+			ctx.Cancel()
+		}
+		return nil
+	}
+
+	if pkt.TextType != packet.TextTypeObject {
 		return nil
 	}
 
@@ -44,6 +66,9 @@ func (*TextHandler) Handle(s *Session, pk packet.Packet, ctx *Context) error {
 	if err := json.Unmarshal([]byte(pkt.Message), &messageData); err != nil {
 		s.log.Error("failed to parse message", "error", err)
 		return err
+	}
+	if len(messageData.RawText) == 0 {
+		return nil
 	}
 	message := messageData.RawText[0].Text
 	if !strings.HasPrefix(message, "[PROXY_SYSTEM][COMMANDS]=") {
@@ -79,7 +104,7 @@ func (*TextHandler) Handle(s *Session, pk packet.Packet, ctx *Context) error {
 			return err
 		}
 
-		if err := os.WriteFile(globalCommandPath, commandsJSON, os.ModePerm); err != nil {
+		if err = os.WriteFile(globalCommandPath, commandsJSON, os.ModePerm); err != nil {
 			s.log.Error("failed to write commands file", "error", err)
 			return err
 		}

--- a/gobds/session/handler_text.go
+++ b/gobds/session/handler_text.go
@@ -36,26 +36,7 @@ func (*TextHandler) Handle(s *Session, pk packet.Packet, ctx *Context) error {
 	pkt := pk.(*packet.Text)
 
 	if ctx.Val() == s.client {
-		if len(pkt.Message) > s.traffic.config.MaxTextBytes || len(pkt.SourceName) > 256 ||
-			len(pkt.Parameters) > 64 {
-			s.traffic.malformed(trafficChat)
-			return malformedPacketError{reason: "text payload exceeds maximum length"}
-		}
-		for _, parameter := range pkt.Parameters {
-			if len(parameter) > s.traffic.config.MaxTextBytes {
-				s.traffic.malformed(trafficChat)
-				return malformedPacketError{reason: "text parameter exceeds maximum length"}
-			}
-		}
-		if strings.TrimSpace(pkt.Message) == "" {
-			s.traffic.malformed(trafficChat)
-			ctx.Cancel()
-			return nil
-		}
-		if !s.traffic.allow(trafficChat) {
-			ctx.Cancel()
-		}
-		return nil
+		return handleClientText(s, pkt, ctx)
 	}
 
 	if pkt.TextType != packet.TextTypeObject {
@@ -113,5 +94,28 @@ func (*TextHandler) Handle(s *Session, pk packet.Packet, ctx *Context) error {
 	// Reload commands immediately
 	cmd.LoadFrom(commands)
 	s.log.Info("reloaded commands from server", "count", len(commands))
+	return nil
+}
+
+func handleClientText(s *Session, pkt *packet.Text, ctx *Context) error {
+	if len(pkt.Message) > s.traffic.config.MaxTextBytes || len(pkt.SourceName) > 256 ||
+		len(pkt.Parameters) > 64 {
+		s.traffic.malformed(trafficChat)
+		return malformedPacketError{reason: "text payload exceeds maximum length"}
+	}
+	for _, parameter := range pkt.Parameters {
+		if len(parameter) > s.traffic.config.MaxTextBytes {
+			s.traffic.malformed(trafficChat)
+			return malformedPacketError{reason: "text parameter exceeds maximum length"}
+		}
+	}
+	if strings.TrimSpace(pkt.Message) == "" {
+		s.traffic.malformed(trafficChat)
+		ctx.Cancel()
+		return nil
+	}
+	if !s.traffic.allow(trafficChat) {
+		ctx.Cancel()
+	}
 	return nil
 }

--- a/gobds/session/handler_update_abilities.go
+++ b/gobds/session/handler_update_abilities.go
@@ -1,0 +1,40 @@
+package session
+
+import (
+	"math"
+
+	"github.com/sandertv/gophertunnel/minecraft/protocol"
+	"github.com/sandertv/gophertunnel/minecraft/protocol/packet"
+)
+
+// UpdateAbilitiesHandler ...
+type UpdateAbilitiesHandler struct{}
+
+// Handle ...
+func (*UpdateAbilitiesHandler) Handle(s *Session, pk packet.Packet, ctx *Context) error {
+	pkt := pk.(*packet.UpdateAbilities)
+	if ctx.Val() != s.server {
+		return nil
+	}
+	abilityData := pkt.AbilityData
+	if abilityData.EntityUniqueID != s.GameData().EntityUniqueID {
+		return nil
+	}
+
+	prevOperator := s.Data().Operator()
+	operator := abilityData.PlayerPermissions == packet.PermissionLevelOperator
+	if prevOperator == operator {
+		return nil
+	}
+
+	s.Data().SetOperator(operator)
+	position := s.Position()
+	s.WriteToClient(&packet.LevelChunk{
+		Position: protocol.ChunkPos{
+			int32(math.Floor(float64(position.X()))) >> 4,
+			int32(math.Floor(float64(position.Z()))) >> 4,
+		},
+		SubChunkCount: protocol.SubChunkRequestModeLimited,
+	})
+	return nil
+}

--- a/gobds/session/handler_update_abilities.go
+++ b/gobds/session/handler_update_abilities.go
@@ -29,12 +29,14 @@ func (*UpdateAbilitiesHandler) Handle(s *Session, pk packet.Packet, ctx *Context
 
 	s.Data().SetOperator(operator)
 	position := s.Position()
-	s.WriteToClient(&packet.LevelChunk{
-		Position: protocol.ChunkPos{
-			int32(math.Floor(float64(position.X()))) >> 4,
-			int32(math.Floor(float64(position.Z()))) >> 4,
-		},
-		SubChunkCount: protocol.SubChunkRequestModeLimited,
-	})
+	chunkPos := protocol.ChunkPos{
+		int32(math.Floor(float64(position.X()))) >> 4,
+		int32(math.Floor(float64(position.Z()))) >> 4,
+	}
+	correction, ok := correctiveLevelChunk(chunkPos, s.Data().Dimension(), s.GameData().Dimensions)
+	if !ok {
+		return nil
+	}
+	s.WriteToClient(correction)
 	return nil
 }

--- a/gobds/session/handler_update_player_game_type.go
+++ b/gobds/session/handler_update_player_game_type.go
@@ -1,0 +1,19 @@
+package session
+
+import "github.com/sandertv/gophertunnel/minecraft/protocol/packet"
+
+// UpdatePlayerGameTypeHandler ...
+type UpdatePlayerGameTypeHandler struct{}
+
+// Handle ...
+func (*UpdatePlayerGameTypeHandler) Handle(s *Session, pk packet.Packet, ctx *Context) error {
+	pkt := pk.(*packet.UpdatePlayerGameType)
+	if ctx.Val() != s.server {
+		return nil
+	}
+	if pkt.PlayerUniqueID != s.GameData().EntityUniqueID {
+		return nil
+	}
+	s.Data().SetGameMode(pkt.GameType)
+	return nil
+}

--- a/gobds/session/session.go
+++ b/gobds/session/session.go
@@ -2,8 +2,11 @@ package session
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"log/slog"
+	"math"
 	"sync"
 	"time"
 
@@ -11,6 +14,7 @@ import (
 	"github.com/df-mc/dragonfly/server/session"
 	"github.com/go-gl/mathgl/mgl32"
 	"github.com/sandertv/gophertunnel/minecraft"
+	"github.com/sandertv/gophertunnel/minecraft/protocol"
 	"github.com/sandertv/gophertunnel/minecraft/protocol/login"
 	"github.com/sandertv/gophertunnel/minecraft/protocol/packet"
 	"github.com/smell-of-curry/gobds/gobds/claim"
@@ -32,9 +36,15 @@ type Session struct {
 	afkTimer *infra.AFKTimer
 	border   *area.Area2D
 
+	claimPrefilter     bool
+	claimDenyRendering bool
+
 	close chan struct{}
 
 	afk afkState
+
+	corrective correctiveState
+	traffic    trafficState
 
 	// lastForwardedPing is the last client latency (ms) sent to BDS via
 	// ForwardPing. -1 means nothing has been forwarded yet.
@@ -60,6 +70,24 @@ type afkState struct {
 	warnedApproaching bool
 	markedAFK         bool
 	warnedFinal       bool
+}
+
+type correctiveState struct {
+	mu   sync.Mutex
+	last map[correctiveKey]time.Time
+}
+
+type correctiveKey struct {
+	dimension int32
+	x, z      int32
+}
+
+type malformedPacketError struct {
+	reason string
+}
+
+func (e malformedPacketError) Error() string {
+	return "malformed packet: " + e.reason
 }
 
 // AFKTimer returns the session's AFK configuration, or nil if disabled.
@@ -90,6 +118,44 @@ func (s *Session) TouchMovement(pos mgl32.Vec3, yaw, pitch float32) bool {
 	s.afk.markedAFK = false
 	s.afk.warnedFinal = false
 	return true
+}
+
+// Position returns the latest sampled player position.
+func (s *Session) Position() mgl32.Vec3 {
+	s.afk.mu.RLock()
+	defer s.afk.mu.RUnlock()
+	return s.afk.lastPosition
+}
+
+func (s *Session) allowCorrective(chunkPos protocol.ChunkPos, interval time.Duration) bool {
+	key := correctiveKey{
+		dimension: s.Data().Dimension(),
+		x:         chunkPos.X(),
+		z:         chunkPos.Z(),
+	}
+	now := time.Now()
+	s.corrective.mu.Lock()
+	defer s.corrective.mu.Unlock()
+	if now.Sub(s.corrective.last[key]) < interval {
+		return false
+	}
+	s.corrective.last[key] = now
+	return true
+}
+
+func (s *Session) claimMessage(position mgl32.Vec3, message string) {
+	chunkPos := protocol.ChunkPos{
+		int32(math.Floor(float64(position.X()))) >> 4,
+		int32(math.Floor(float64(position.Z()))) >> 4,
+	}
+	if s.allowCorrective(chunkPos, time.Second) {
+		s.Message(message)
+		if s.claimFactory != nil {
+			s.claimFactory.Metrics().Correction(true)
+		}
+	} else if s.claimFactory != nil {
+		s.claimFactory.Metrics().Correction(false)
+	}
 }
 
 // AFKDuration returns how long the session has been idle. Before the first
@@ -318,18 +384,34 @@ func (s *Session) Server() session.Conn {
 }
 
 // handlePacket passes packet into corresponding handler.
-func (s *Session) handlePacket(p packet.Packet, conn Conn) (bool, error) {
+func (s *Session) handlePacket(p packet.Packet, conn Conn) (send bool, err error) {
 	handler, ok := s.handlers[p.ID()]
-	if ok {
-		ctx := event.C(conn)
-		err := handler.Handle(s, p, ctx)
-		if err != nil {
-			s.log.Error("error handling packet", "packet", p, "error", err)
-			s.Disconnect(err.Error())
-		}
-		return !ctx.Cancelled(), err
+	if !ok {
+		return true, nil
 	}
-	return true, nil
+	ctx := event.C(conn)
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			s.traffic.malformed(trafficHandler)
+			s.log.Error("panic handling packet", "packet_id", p.ID(), "error", recovered)
+			s.Disconnect("Malformed client packet.")
+			send = false
+			err = fmt.Errorf("panic handling packet %d: %v", p.ID(), recovered)
+		}
+	}()
+	err = handler.Handle(s, p, ctx)
+	if err == nil {
+		return !ctx.Cancelled(), nil
+	}
+	s.log.Error("error handling packet", "packet_id", p.ID(), "error", err)
+	var malformed malformedPacketError
+	if errors.As(err, &malformed) {
+		s.Disconnect("Malformed client packet.")
+		return false, err
+	}
+	// Handler failures drop only this packet. Claim and subchunk handlers are
+	// fail-open internally; unrelated backend failures must not disconnect sessions.
+	return false, nil
 }
 
 // registerHandlers registers all packet handlers.
@@ -338,16 +420,28 @@ func (s *Session) registerHandlers() {
 		packet.IDAddActor:             &AddActorHandler{},
 		packet.IDAddPainting:          &AddPaintingHandler{},
 		packet.IDAvailableCommands:    &AvailableCommandsHandler{},
+		packet.IDChangeDimension:      &ChangeDimensionHandler{},
 		packet.IDCommandRequest:       &CommandRequestHandler{},
 		packet.IDInventoryTransaction: &InventoryTransactionHandler{},
 		packet.IDItemRegistry:         &ItemRegistryHandler{},
 		packet.IDItemStackRequest:     &ItemStackRequestHandler{},
 		packet.IDLevelChunk:           &LevelChunkHandler{},
 		packet.IDModalFormRequest:     &ModalFormRequestHandler{},
+		packet.IDModalFormResponse:    &ModalFormResponseHandler{},
+		packet.IDMoveActorAbsolute:    &MoveActorHandler{},
+		packet.IDMoveActorDelta:       &MoveActorHandler{},
 		packet.IDPlayerAuthInput:      NewPlayerAuthInputHandler(),
 		packet.IDRemoveActor:          &RemoveActorHandler{},
 		packet.IDSetActorData:         &SetActorDataHandler{},
+		packet.IDSetPlayerGameType:    &SetPlayerGameTypeHandler{},
 		packet.IDSubChunk:             &SubChunkHandler{},
 		packet.IDText:                 &TextHandler{},
+		packet.IDUpdateAbilities:      &UpdateAbilitiesHandler{},
+		packet.IDUpdatePlayerGameType: &UpdatePlayerGameTypeHandler{},
 	}
+}
+
+// WriteTrafficMetrics emits and resets this session's traffic metric delta.
+func (s *Session) WriteTrafficMetrics(output io.Writer, server string, period time.Duration) {
+	s.traffic.session.WriteDelta(output, server, s.IdentityData().XUID, period)
 }

--- a/gobds/session/traffic.go
+++ b/gobds/session/traffic.go
@@ -1,0 +1,256 @@
+package session
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+const trafficCategories = 6
+
+const (
+	trafficChat = iota
+	trafficCommand
+	trafficForm
+	trafficInventory
+	trafficStack
+	trafficHandler
+)
+
+var trafficCategoryNames = [trafficCategories]string{
+	"chat", "command", "form", "inventory", "item_stack", "handler",
+}
+
+// RateLimit configures one per-session token bucket.
+type RateLimit struct {
+	Rate  float64
+	Burst int
+}
+
+// TrafficConfig bounds malformed packets and optionally enforces rate limits.
+type TrafficConfig struct {
+	Enforce bool
+
+	Chat                  RateLimit
+	Commands              RateLimit
+	ModalFormResponses    RateLimit
+	InventoryTransactions RateLimit
+	ItemStackRequests     RateLimit
+
+	MaxTextBytes          int
+	MaxCommandBytes       int
+	MaxFormResponseBytes  int
+	MaxFormResponseValues int
+	MaxInventoryActions   int
+	MaxStackRequests      int
+	MaxStackActions       int
+	MaxTotalStackActions  int
+}
+
+// DefaultTrafficConfig returns safe observe-only limits.
+func DefaultTrafficConfig() TrafficConfig {
+	return TrafficConfig{
+		Chat:                  RateLimit{Rate: 8, Burst: 16},
+		Commands:              RateLimit{Rate: 4, Burst: 8},
+		ModalFormResponses:    RateLimit{Rate: 10, Burst: 20},
+		InventoryTransactions: RateLimit{Rate: 60, Burst: 120},
+		ItemStackRequests:     RateLimit{Rate: 40, Burst: 80},
+		MaxTextBytes:          4 << 10,
+		MaxCommandBytes:       4 << 10,
+		MaxFormResponseBytes:  64 << 10,
+		MaxFormResponseValues: 128,
+		MaxInventoryActions:   128,
+		MaxStackRequests:      64,
+		MaxStackActions:       128,
+		MaxTotalStackActions:  256,
+	}
+}
+
+// WithDefaults fills zero values, including when the config section is missing.
+func (c TrafficConfig) WithDefaults() TrafficConfig {
+	defaults := DefaultTrafficConfig()
+	if c.Chat.Rate <= 0 {
+		c.Chat.Rate = defaults.Chat.Rate
+	}
+	if c.Chat.Burst <= 0 {
+		c.Chat.Burst = defaults.Chat.Burst
+	}
+	if c.Commands.Rate <= 0 {
+		c.Commands.Rate = defaults.Commands.Rate
+	}
+	if c.Commands.Burst <= 0 {
+		c.Commands.Burst = defaults.Commands.Burst
+	}
+	if c.ModalFormResponses.Rate <= 0 {
+		c.ModalFormResponses.Rate = defaults.ModalFormResponses.Rate
+	}
+	if c.ModalFormResponses.Burst <= 0 {
+		c.ModalFormResponses.Burst = defaults.ModalFormResponses.Burst
+	}
+	if c.InventoryTransactions.Rate <= 0 {
+		c.InventoryTransactions.Rate = defaults.InventoryTransactions.Rate
+	}
+	if c.InventoryTransactions.Burst <= 0 {
+		c.InventoryTransactions.Burst = defaults.InventoryTransactions.Burst
+	}
+	if c.ItemStackRequests.Rate <= 0 {
+		c.ItemStackRequests.Rate = defaults.ItemStackRequests.Rate
+	}
+	if c.ItemStackRequests.Burst <= 0 {
+		c.ItemStackRequests.Burst = defaults.ItemStackRequests.Burst
+	}
+	if c.MaxTextBytes <= 0 {
+		c.MaxTextBytes = defaults.MaxTextBytes
+	}
+	if c.MaxCommandBytes <= 0 {
+		c.MaxCommandBytes = defaults.MaxCommandBytes
+	}
+	if c.MaxFormResponseBytes <= 0 {
+		c.MaxFormResponseBytes = defaults.MaxFormResponseBytes
+	}
+	if c.MaxFormResponseValues <= 0 {
+		c.MaxFormResponseValues = defaults.MaxFormResponseValues
+	}
+	if c.MaxInventoryActions <= 0 {
+		c.MaxInventoryActions = defaults.MaxInventoryActions
+	}
+	if c.MaxStackRequests <= 0 {
+		c.MaxStackRequests = defaults.MaxStackRequests
+	}
+	if c.MaxStackActions <= 0 {
+		c.MaxStackActions = defaults.MaxStackActions
+	}
+	if c.MaxTotalStackActions <= 0 {
+		c.MaxTotalStackActions = defaults.MaxTotalStackActions
+	}
+	return c
+}
+
+type tokenBucket struct {
+	mu     sync.Mutex
+	rate   float64
+	burst  float64
+	tokens float64
+	last   time.Time
+}
+
+func newTokenBucket(limit RateLimit, now time.Time) tokenBucket {
+	return tokenBucket{rate: limit.Rate, burst: float64(limit.Burst), tokens: float64(limit.Burst), last: now}
+}
+
+func (b *tokenBucket) allow(now time.Time) bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	elapsed := now.Sub(b.last).Seconds()
+	if elapsed > 0 {
+		b.tokens = min(b.burst, b.tokens+elapsed*b.rate)
+		b.last = now
+	}
+	if b.tokens < 1 {
+		return false
+	}
+	b.tokens--
+	return true
+}
+
+// TrafficMetrics contains dependency-free atomic traffic counters.
+type TrafficMetrics struct {
+	observed  [trafficCategories]atomic.Uint64
+	exceeded  [trafficCategories]atomic.Uint64
+	enforced  [trafficCategories]atomic.Uint64
+	malformed [trafficCategories]atomic.Uint64
+}
+
+func (m *TrafficMetrics) observe(category int, exceeded, enforced bool) {
+	if m == nil || category < 0 || category >= trafficCategories {
+		return
+	}
+	m.observed[category].Add(1)
+	if exceeded {
+		m.exceeded[category].Add(1)
+	}
+	if enforced {
+		m.enforced[category].Add(1)
+	}
+}
+
+func (m *TrafficMetrics) malformedPacket(category int) {
+	if m != nil && category >= 0 && category < trafficCategories {
+		m.malformed[category].Add(1)
+	}
+}
+
+type trafficMetricRecord struct {
+	Type       string                    `json:"type"`
+	Server     string                    `json:"server"`
+	Session    string                    `json:"session,omitempty"`
+	PeriodMS   int64                     `json:"period_ms"`
+	Categories [trafficCategories]string `json:"categories"`
+	Observed   [trafficCategories]uint64 `json:"observed"`
+	Exceeded   [trafficCategories]uint64 `json:"exceeded"`
+	Enforced   [trafficCategories]uint64 `json:"enforced"`
+	Malformed  [trafficCategories]uint64 `json:"malformed"`
+}
+
+// WriteDelta emits one compact JSON record and resets interval counters.
+func (m *TrafficMetrics) WriteDelta(output io.Writer, server, session string, period time.Duration) {
+	if m == nil {
+		return
+	}
+	record := trafficMetricRecord{
+		Type:       "traffic_protection_metrics",
+		Server:     server,
+		Session:    session,
+		PeriodMS:   period.Milliseconds(),
+		Categories: trafficCategoryNames,
+	}
+	for i := range trafficCategories {
+		record.Observed[i] = m.observed[i].Swap(0)
+		record.Exceeded[i] = m.exceeded[i].Swap(0)
+		record.Enforced[i] = m.enforced[i].Swap(0)
+		record.Malformed[i] = m.malformed[i].Swap(0)
+	}
+	raw, err := json.Marshal(record)
+	if err == nil {
+		_, _ = fmt.Fprintln(output, string(raw))
+	}
+}
+
+type trafficState struct {
+	config    TrafficConfig
+	buckets   [trafficCategories]tokenBucket
+	session   TrafficMetrics
+	aggregate *TrafficMetrics
+}
+
+func newTrafficState(config TrafficConfig, aggregate *TrafficMetrics) trafficState {
+	config = config.WithDefaults()
+	now := time.Now()
+	return trafficState{
+		config: config,
+		buckets: [trafficCategories]tokenBucket{
+			newTokenBucket(config.Chat, now),
+			newTokenBucket(config.Commands, now),
+			newTokenBucket(config.ModalFormResponses, now),
+			newTokenBucket(config.InventoryTransactions, now),
+			newTokenBucket(config.ItemStackRequests, now),
+		},
+		aggregate: aggregate,
+	}
+}
+
+func (t *trafficState) allow(category int) bool {
+	exceeded := !t.buckets[category].allow(time.Now())
+	enforced := exceeded && t.config.Enforce
+	t.session.observe(category, exceeded, enforced)
+	t.aggregate.observe(category, exceeded, enforced)
+	return !enforced
+}
+
+func (t *trafficState) malformed(category int) {
+	t.session.malformedPacket(category)
+	t.aggregate.malformedPacket(category)
+}

--- a/gobds/session/traffic.go
+++ b/gobds/session/traffic.go
@@ -69,63 +69,39 @@ func DefaultTrafficConfig() TrafficConfig {
 	}
 }
 
+func setDefaultRate(v *float64, def float64) {
+	if *v <= 0 {
+		*v = def
+	}
+}
+
+func setDefaultBurst(v *int, def int) {
+	if *v <= 0 {
+		*v = def
+	}
+}
+
 // WithDefaults fills zero values, including when the config section is missing.
 func (c TrafficConfig) WithDefaults() TrafficConfig {
 	defaults := DefaultTrafficConfig()
-	if c.Chat.Rate <= 0 {
-		c.Chat.Rate = defaults.Chat.Rate
-	}
-	if c.Chat.Burst <= 0 {
-		c.Chat.Burst = defaults.Chat.Burst
-	}
-	if c.Commands.Rate <= 0 {
-		c.Commands.Rate = defaults.Commands.Rate
-	}
-	if c.Commands.Burst <= 0 {
-		c.Commands.Burst = defaults.Commands.Burst
-	}
-	if c.ModalFormResponses.Rate <= 0 {
-		c.ModalFormResponses.Rate = defaults.ModalFormResponses.Rate
-	}
-	if c.ModalFormResponses.Burst <= 0 {
-		c.ModalFormResponses.Burst = defaults.ModalFormResponses.Burst
-	}
-	if c.InventoryTransactions.Rate <= 0 {
-		c.InventoryTransactions.Rate = defaults.InventoryTransactions.Rate
-	}
-	if c.InventoryTransactions.Burst <= 0 {
-		c.InventoryTransactions.Burst = defaults.InventoryTransactions.Burst
-	}
-	if c.ItemStackRequests.Rate <= 0 {
-		c.ItemStackRequests.Rate = defaults.ItemStackRequests.Rate
-	}
-	if c.ItemStackRequests.Burst <= 0 {
-		c.ItemStackRequests.Burst = defaults.ItemStackRequests.Burst
-	}
-	if c.MaxTextBytes <= 0 {
-		c.MaxTextBytes = defaults.MaxTextBytes
-	}
-	if c.MaxCommandBytes <= 0 {
-		c.MaxCommandBytes = defaults.MaxCommandBytes
-	}
-	if c.MaxFormResponseBytes <= 0 {
-		c.MaxFormResponseBytes = defaults.MaxFormResponseBytes
-	}
-	if c.MaxFormResponseValues <= 0 {
-		c.MaxFormResponseValues = defaults.MaxFormResponseValues
-	}
-	if c.MaxInventoryActions <= 0 {
-		c.MaxInventoryActions = defaults.MaxInventoryActions
-	}
-	if c.MaxStackRequests <= 0 {
-		c.MaxStackRequests = defaults.MaxStackRequests
-	}
-	if c.MaxStackActions <= 0 {
-		c.MaxStackActions = defaults.MaxStackActions
-	}
-	if c.MaxTotalStackActions <= 0 {
-		c.MaxTotalStackActions = defaults.MaxTotalStackActions
-	}
+	setDefaultRate(&c.Chat.Rate, defaults.Chat.Rate)
+	setDefaultBurst(&c.Chat.Burst, defaults.Chat.Burst)
+	setDefaultRate(&c.Commands.Rate, defaults.Commands.Rate)
+	setDefaultBurst(&c.Commands.Burst, defaults.Commands.Burst)
+	setDefaultRate(&c.ModalFormResponses.Rate, defaults.ModalFormResponses.Rate)
+	setDefaultBurst(&c.ModalFormResponses.Burst, defaults.ModalFormResponses.Burst)
+	setDefaultRate(&c.InventoryTransactions.Rate, defaults.InventoryTransactions.Rate)
+	setDefaultBurst(&c.InventoryTransactions.Burst, defaults.InventoryTransactions.Burst)
+	setDefaultRate(&c.ItemStackRequests.Rate, defaults.ItemStackRequests.Rate)
+	setDefaultBurst(&c.ItemStackRequests.Burst, defaults.ItemStackRequests.Burst)
+	setDefaultBurst(&c.MaxTextBytes, defaults.MaxTextBytes)
+	setDefaultBurst(&c.MaxCommandBytes, defaults.MaxCommandBytes)
+	setDefaultBurst(&c.MaxFormResponseBytes, defaults.MaxFormResponseBytes)
+	setDefaultBurst(&c.MaxFormResponseValues, defaults.MaxFormResponseValues)
+	setDefaultBurst(&c.MaxInventoryActions, defaults.MaxInventoryActions)
+	setDefaultBurst(&c.MaxStackRequests, defaults.MaxStackRequests)
+	setDefaultBurst(&c.MaxStackActions, defaults.MaxStackActions)
+	setDefaultBurst(&c.MaxTotalStackActions, defaults.MaxTotalStackActions)
 	return c
 }
 

--- a/gobds/session/traffic_test.go
+++ b/gobds/session/traffic_test.go
@@ -1,0 +1,88 @@
+package session
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestCommandNameHandlesEmptyAndMalformedWithoutSlicing(t *testing.T) {
+	for _, line := range []string{"", " ", "/"} {
+		if _, empty, err := commandName(line, 16); err != nil || !empty {
+			t.Fatalf("line %q: empty=%v err=%v", line, empty, err)
+		}
+	}
+	if name, empty, err := commandName("/HeLp arg", 16); err != nil || empty || name != "help" {
+		t.Fatalf("valid command: name=%q empty=%v err=%v", name, empty, err)
+	}
+	if name, empty, err := commandName("uncertain", 16); err != nil || empty || name != "" {
+		t.Fatalf("uncertain command should pass through: name=%q empty=%v err=%v", name, empty, err)
+	}
+	_, _, err := commandName("/this-is-too-long", 4)
+	var malformed malformedPacketError
+	if !errors.As(err, &malformed) {
+		t.Fatalf("oversized command returned %v", err)
+	}
+}
+
+func TestTrafficDefaultsApplyToMissingSection(t *testing.T) {
+	got := (TrafficConfig{}).WithDefaults()
+	want := DefaultTrafficConfig()
+	if got.Enforce {
+		t.Fatal("traffic enforcement must default off")
+	}
+	if got.Chat != want.Chat || got.Commands != want.Commands ||
+		got.MaxTextBytes != want.MaxTextBytes || got.MaxTotalStackActions != want.MaxTotalStackActions {
+		t.Fatalf("missing config did not receive defaults: got=%+v want=%+v", got, want)
+	}
+}
+
+func TestTokenBucketObserveOnlyAndEnforcement(t *testing.T) {
+	config := DefaultTrafficConfig()
+	config.Chat = RateLimit{Rate: 0.0001, Burst: 1}
+	observe := newTrafficState(config, nil)
+	if !observe.allow(trafficChat) || !observe.allow(trafficChat) {
+		t.Fatal("observe-only bucket must preserve forwarding")
+	}
+
+	config.Enforce = true
+	enforce := newTrafficState(config, nil)
+	if !enforce.allow(trafficChat) || enforce.allow(trafficChat) {
+		t.Fatal("enforced bucket must drop only excess")
+	}
+
+	var output bytes.Buffer
+	enforce.session.WriteDelta(&output, "TEST", "xuid", time.Minute)
+	var record trafficMetricRecord
+	if err := json.Unmarshal(output.Bytes(), &record); err != nil {
+		t.Fatal(err)
+	}
+	if record.Observed[trafficChat] != 2 || record.Exceeded[trafficChat] != 1 ||
+		record.Enforced[trafficChat] != 1 {
+		t.Fatalf("unexpected metrics: %+v", record)
+	}
+}
+
+func TestFormResponseBoundsAndStructure(t *testing.T) {
+	config := DefaultTrafficConfig()
+	config.MaxFormResponseBytes = 8
+	config.MaxFormResponseValues = 1
+	for _, response := range [][]byte{
+		{},
+		[]byte("{"),
+		[]byte(`"12345678"`),
+		[]byte(`[0,1]`),
+	} {
+		var malformed malformedPacketError
+		if err := validateFormResponse(response, config); !errors.As(err, &malformed) {
+			t.Fatalf("response %q returned %v", response, err)
+		}
+	}
+	for _, response := range [][]byte{[]byte(`true`), []byte(`[0]`), []byte(`null`)} {
+		if err := validateFormResponse(response, config); err != nil {
+			t.Fatalf("valid response %q rejected: %v", response, err)
+		}
+	}
+}

--- a/gobds/session/util.go
+++ b/gobds/session/util.go
@@ -1,0 +1,95 @@
+package session
+
+import (
+	"github.com/df-mc/dragonfly/server/block/cube"
+	"github.com/df-mc/dragonfly/server/world"
+	"github.com/go-gl/mathgl/mgl32"
+	"github.com/sandertv/gophertunnel/minecraft/protocol"
+	gblock "github.com/smell-of-curry/gobds/gobds/block"
+	"github.com/smell-of-curry/gobds/gobds/claim"
+)
+
+var (
+	denyRuntimeID       uint32
+	hashedDenyRuntimeID uint32
+)
+
+// SetupRuntimeIDs ...
+func SetupRuntimeIDs() {
+	registry := world.DefaultBlockRegistry
+	denyRuntimeID = registry.BlockRuntimeID(gblock.Deny{})
+	var ok bool
+	hashedDenyRuntimeID, ok = registry.RuntimeIDToHash(denyRuntimeID)
+	if !ok {
+		panic("cannot find hashed deny runtime ID")
+	}
+}
+
+// blockByRuntimeID ...
+func blockByRuntimeID(id uint32, hashed bool) (world.Block, bool) {
+	registry := world.DefaultBlockRegistry
+	if hashed {
+		var ok bool
+		id, ok = registry.HashToRuntimeID(id)
+		if !ok {
+			return nil, false
+		}
+	}
+	return registry.BlockByRuntimeID(id)
+}
+
+// denyBlockRuntimeID ...
+func denyBlockRuntimeID(hashed bool) uint32 {
+	if hashed {
+		return hashedDenyRuntimeID
+	}
+	return denyRuntimeID
+}
+
+func claimDimensionFromInt(dimension int32, definitions []protocol.DimensionDefinition) (string, bool) {
+	switch dimension {
+	case 0:
+		return "minecraft:overworld", true
+	case 1:
+		return "minecraft:nether", true
+	case 2:
+		return "minecraft:end", true
+	}
+	var resolved string
+	for _, definition := range definitions {
+		if definition.DimensionType != dimension {
+			continue
+		}
+		name, ok := claim.CanonicalDimension(definition.Name)
+		if !ok || resolved != "" && resolved != name {
+			return "", false
+		}
+		resolved = name
+	}
+	return resolved, resolved != ""
+}
+
+func dimensionRangeByID(id int32, definitions []protocol.DimensionDefinition) (cube.Range, bool) {
+	for _, definition := range definitions {
+		if definition.DimensionType == id {
+			return cube.Range{int(definition.Range[0]), int(definition.Range[1])}, true
+		}
+	}
+	if dimension, ok := world.DimensionByID(int(id)); ok {
+		return dimension.Range(), true
+	}
+	return cube.Range{}, false
+}
+
+func claimContains(c claim.PlayerClaim, x, z float32) bool {
+	minX := min(c.Location.Pos1.X, c.Location.Pos2.X)
+	maxX := max(c.Location.Pos1.X, c.Location.Pos2.X)
+	minZ := min(c.Location.Pos1.Z, c.Location.Pos2.Z)
+	maxZ := max(c.Location.Pos1.Z, c.Location.Pos2.Z)
+	return x >= minX && x <= maxX && z >= minZ && z <= maxZ
+}
+
+// blockPosToVec3 ...
+func blockPosToVec3(pos protocol.BlockPos) mgl32.Vec3 {
+	return mgl32.Vec3{float32(pos.X()), float32(pos.Y()), float32(pos.Z())}
+}

--- a/gobds/session/util_claim_action.go
+++ b/gobds/session/util_claim_action.go
@@ -59,15 +59,9 @@ func ClaimActionPermitted(cl claim.PlayerClaim, actor ClaimActor, action ClaimAc
 	case ClaimActionBlockPlace:
 		return handleClaimActionInFeature(cl, data, claim.FeatureTypeBlockPlaceable)
 	case ClaimActionBlockInteract:
-		if cl.OwnerXUID == "*" && adminClaimBlockInteractionAllowed(data) {
-			return true
-		}
-		return handleClaimActionInFeature(cl, data, claim.FeatureTypeBlockInteractable)
+		return claimActionBlockInteractPermitted(cl, data)
 	case ClaimActionEntityInteract:
-		if cl.OwnerXUID == "*" {
-			return true
-		}
-		return handleClaimActionInFeature(cl, data, claim.FeatureTypeEntityInteractable)
+		return claimActionEntityInteractPermitted(cl, data)
 	case ClaimActionEntityHurt:
 		return handleClaimActionInFeature(cl, data, claim.FeatureTypeEntityHurt)
 	case ClaimActionItemRelease, ClaimActionItemThrow:
@@ -75,12 +69,30 @@ func ClaimActionPermitted(cl claim.PlayerClaim, actor ClaimActor, action ClaimAc
 		// throwables are not item drops. BEH does not claim-filter either.
 		return true
 	case ClaimActionItemDrop:
-		if cl.OwnerXUID == "*" {
-			return true
-		}
-		return handleClaimActionInFeature(cl, data, claim.FeatureTypeDropItems)
+		return claimActionItemDropPermitted(cl, data)
 	}
 	return true
+}
+
+func claimActionBlockInteractPermitted(cl claim.PlayerClaim, data any) bool {
+	if cl.OwnerXUID == "*" && adminClaimBlockInteractionAllowed(data) {
+		return true
+	}
+	return handleClaimActionInFeature(cl, data, claim.FeatureTypeBlockInteractable)
+}
+
+func claimActionEntityInteractPermitted(cl claim.PlayerClaim, data any) bool {
+	if cl.OwnerXUID == "*" {
+		return true
+	}
+	return handleClaimActionInFeature(cl, data, claim.FeatureTypeEntityInteractable)
+}
+
+func claimActionItemDropPermitted(cl claim.PlayerClaim, data any) bool {
+	if cl.OwnerXUID == "*" {
+		return true
+	}
+	return handleClaimActionInFeature(cl, data, claim.FeatureTypeDropItems)
 }
 
 func adminClaimBlockInteractionAllowed(data any) bool {
@@ -97,15 +109,6 @@ func adminClaimBlockInteractionAllowed(data any) bool {
 	default:
 		return false
 	}
-}
-
-func claimActionsPermitted(claims []claim.PlayerClaim, actor ClaimActor, action ClaimAction, data any) bool {
-	for _, cl := range claims {
-		if !ClaimActionPermitted(cl, actor, action, data) {
-			return false
-		}
-	}
-	return true
 }
 
 func (s *Session) claimActionPermitted(action ClaimAction, data any) bool {

--- a/gobds/session/util_claim_action.go
+++ b/gobds/session/util_claim_action.go
@@ -1,0 +1,293 @@
+package session
+
+import (
+	"slices"
+	"time"
+
+	"github.com/go-gl/mathgl/mgl32"
+	"github.com/smell-of-curry/gobds/gobds/claim"
+)
+
+// ClaimAction ...
+type ClaimAction uint8
+
+type claimActionData struct {
+	position mgl32.Vec3
+	typeID   string
+}
+
+// ClaimActor contains only player state needed by claim policy evaluation.
+type ClaimActor struct {
+	XUID     string
+	Operator bool
+}
+
+const (
+	// ClaimActionRender ...
+	ClaimActionRender ClaimAction = iota
+	// ClaimActionBlockBreak ...
+	ClaimActionBlockBreak
+	// ClaimActionBlockPlace ...
+	ClaimActionBlockPlace
+	// ClaimActionBlockInteract ...
+	ClaimActionBlockInteract
+	// ClaimActionEntityInteract ...
+	ClaimActionEntityInteract
+	// ClaimActionEntityHurt ...
+	ClaimActionEntityHurt
+	// ClaimActionItemRelease ...
+	ClaimActionItemRelease
+	// ClaimActionItemThrow ...
+	ClaimActionItemThrow
+	// ClaimActionItemDrop ...
+	ClaimActionItemDrop
+)
+
+// ClaimActionPermitted evaluates claim policy without session or network state.
+func ClaimActionPermitted(cl claim.PlayerClaim, actor ClaimActor, action ClaimAction, data any) bool {
+	if !validClaim(cl) || actor.XUID == "" {
+		return true
+	}
+	if claimOwnerOrTrusted(cl, actor) {
+		return true
+	}
+	switch action {
+	case ClaimActionRender:
+		return handleClaimActionRender(cl, data)
+	case ClaimActionBlockBreak:
+		return handleClaimActionInFeature(cl, data, claim.FeatureTypeMineable)
+	case ClaimActionBlockPlace:
+		return handleClaimActionInFeature(cl, data, claim.FeatureTypeBlockPlaceable)
+	case ClaimActionBlockInteract:
+		if cl.OwnerXUID == "*" && adminClaimBlockInteractionAllowed(data) {
+			return true
+		}
+		return handleClaimActionInFeature(cl, data, claim.FeatureTypeBlockInteractable)
+	case ClaimActionEntityInteract:
+		if cl.OwnerXUID == "*" {
+			return true
+		}
+		return handleClaimActionInFeature(cl, data, claim.FeatureTypeEntityInteractable)
+	case ClaimActionEntityHurt:
+		return handleClaimActionInFeature(cl, data, claim.FeatureTypeEntityHurt)
+	case ClaimActionItemRelease, ClaimActionItemThrow:
+		// ReleaseItem stops item use (food, bows, fishing), while click-air
+		// throwables are not item drops. BEH does not claim-filter either.
+		return true
+	case ClaimActionItemDrop:
+		if cl.OwnerXUID == "*" {
+			return true
+		}
+		return handleClaimActionInFeature(cl, data, claim.FeatureTypeDropItems)
+	}
+	return true
+}
+
+func adminClaimBlockInteractionAllowed(data any) bool {
+	actionData, ok := claimActionDataFrom(data)
+	if !ok {
+		return true
+	}
+	if actionData.typeID == "" {
+		return true
+	}
+	switch actionData.typeID {
+	case "pokeb:pc", "pokeb:healing_machine", "pokeb:trade_machine", "minecraft:ender_chest":
+		return true
+	default:
+		return false
+	}
+}
+
+func claimActionsPermitted(claims []claim.PlayerClaim, actor ClaimActor, action ClaimAction, data any) bool {
+	for _, cl := range claims {
+		if !ClaimActionPermitted(cl, actor, action, data) {
+			return false
+		}
+	}
+	return true
+}
+
+func (s *Session) claimActionPermitted(action ClaimAction, data any) bool {
+	if s.claimFactory == nil {
+		return true
+	}
+	metrics := s.claimFactory.Metrics()
+	if !s.claimPrefilter {
+		metrics.Action(uint8(action), true)
+		return true
+	}
+
+	actionData, ok := claimActionDataFrom(data)
+	if !ok {
+		metrics.Reason(claim.QueryInvalid)
+		metrics.Action(uint8(action), true)
+		return true
+	}
+	snapshot, status := s.claimFactory.Snapshot(time.Now())
+	if status != claim.QueryReady {
+		metrics.Reason(status)
+		metrics.Action(uint8(action), true)
+		return true
+	}
+	dimension, ok := claimDimensionFromInt(s.Data().Dimension(), s.GameData().Dimensions)
+	if !ok {
+		metrics.Reason(claim.QueryUnknownDimension)
+		metrics.Action(uint8(action), true)
+		return true
+	}
+	candidates := snapshot.Candidates(dimension, actionData.position.X(), actionData.position.Z())
+	metrics.Candidates(len(candidates))
+	matched, ambiguous := singleClaimAt(candidates, actionData.position.X(), actionData.position.Z())
+	if ambiguous {
+		metrics.Reason(claim.QueryOverlap)
+		metrics.Action(uint8(action), true)
+		return true
+	}
+	if matched == nil {
+		metrics.Action(uint8(action), true)
+		return true
+	}
+	permitted := ClaimActionPermitted(
+		*matched,
+		ClaimActor{XUID: s.IdentityData().XUID, Operator: s.Data().Operator()},
+		action,
+		data,
+	)
+	metrics.Action(uint8(action), permitted)
+	return permitted
+}
+
+func singleClaimAt(candidates []*claim.PlayerClaim, x, z float32) (*claim.PlayerClaim, bool) {
+	var matched *claim.PlayerClaim
+	for _, candidate := range candidates {
+		if !claimContains(*candidate, x, z) {
+			continue
+		}
+		if matched != nil {
+			return nil, true
+		}
+		matched = candidate
+	}
+	return matched, false
+}
+
+// handleClaimActionRender ...
+func handleClaimActionRender(cl claim.PlayerClaim, data any) (permitted bool) {
+	position, ok := data.(mgl32.Vec3)
+	if !ok {
+		return true
+	}
+	for _, feature := range cl.Features {
+		if !featureRemovesDenyBlock(feature) {
+			continue
+		}
+		pos1, pos2 := featureBounds(cl, feature)
+		if insideVector3(position, pos1, pos2) {
+			return true
+		}
+	}
+	return false
+}
+
+// featureRemovesDenyBlock ...
+func featureRemovesDenyBlock(feature claim.Feature) bool {
+	return feature.Type == claim.FeatureTypeMineable || feature.Type == claim.FeatureTypeBlockPlaceable
+}
+
+// handleClaimActionInFeature ...
+func handleClaimActionInFeature(cl claim.PlayerClaim, data any, featureType string) bool {
+	actionData, ok := claimActionDataFrom(data)
+	if !ok {
+		return true
+	}
+	for _, feature := range cl.Features {
+		if feature.Type != featureType {
+			continue
+		}
+		if insideFeature(cl, feature, actionData.position) && featureAllowsType(feature, featureType, actionData.typeID) {
+			return true
+		}
+	}
+	return false
+}
+
+func claimActionDataFrom(data any) (claimActionData, bool) {
+	switch data := data.(type) {
+	case mgl32.Vec3:
+		return claimActionData{position: data}, true
+	case claimActionData:
+		return data, true
+	default:
+		return claimActionData{}, false
+	}
+}
+
+func featureAllowsType(feature claim.Feature, featureType, typeID string) bool {
+	if typeID == "" {
+		return true
+	}
+	switch featureType {
+	case claim.FeatureTypeMineable, claim.FeatureTypeBlockPlaceable, claim.FeatureTypeBlockInteractable:
+		return feature.BlockTypeIDs == nil || slices.Contains(feature.BlockTypeIDs, typeID)
+	case claim.FeatureTypeEntityInteractable, claim.FeatureTypeEntityHurt:
+		return feature.EntityTypeIDs == nil || slices.Contains(feature.EntityTypeIDs, typeID)
+	case claim.FeatureTypeDropItems:
+		return feature.ItemTypeIDs == nil || slices.Contains(feature.ItemTypeIDs, typeID)
+	default:
+		return true
+	}
+}
+
+// claimOwnerOrTrusted ...
+func claimOwnerOrTrusted(cl claim.PlayerClaim, actor ClaimActor) bool {
+	return cl.OwnerXUID == actor.XUID || slices.Contains(cl.TrustedXUIDS, actor.XUID) || actor.Operator
+}
+
+func validClaim(cl claim.PlayerClaim) bool {
+	return cl.ID != "" && cl.OwnerXUID != "" && cl.Location.Dimension != ""
+}
+
+// featureBounds ...
+func featureBounds(cl claim.PlayerClaim, feature claim.Feature) (claim.Vector2, claim.Vector2) {
+	from := cl.Location.Pos1
+	to := cl.Location.Pos2
+	if feature.FromLocation != nil {
+		from = claim.Vector2{X: feature.FromLocation.X, Z: feature.FromLocation.Z}
+	}
+	if feature.ToLocation != nil {
+		to = claim.Vector2{X: feature.ToLocation.X, Z: feature.ToLocation.Z}
+	}
+	return from, to
+}
+
+// insideFeature ...
+func insideFeature(cl claim.PlayerClaim, feature claim.Feature, position mgl32.Vec3) bool {
+	from, to := featureBounds(cl, feature)
+	if !insideVector3(position, from, to) {
+		return false
+	}
+	if feature.FromLocation != nil && feature.ToLocation != nil {
+		minY := min(feature.FromLocation.Y, feature.ToLocation.Y)
+		maxY := max(feature.FromLocation.Y, feature.ToLocation.Y)
+		return position.Y() >= minY && position.Y() <= maxY
+	}
+	if feature.FromLocation != nil {
+		return position.Y() >= feature.FromLocation.Y
+	}
+	if feature.ToLocation != nil {
+		return position.Y() <= feature.ToLocation.Y
+	}
+	return true
+}
+
+// insideVector3 ...
+func insideVector3(vec3 mgl32.Vec3, pos1, pos2 claim.Vector2) bool {
+	minX := min(pos1.X, pos2.X)
+	maxX := max(pos1.X, pos2.X)
+	minZ := min(pos1.Z, pos2.Z)
+	maxZ := max(pos1.Z, pos2.Z)
+
+	return vec3.X() >= minX && vec3.X() <= maxX &&
+		vec3.Z() >= minZ && vec3.Z() <= maxZ
+}

--- a/gobds/session/util_claim_action_test.go
+++ b/gobds/session/util_claim_action_test.go
@@ -324,6 +324,15 @@ func TestClaimsAtHandlesReversedAndOverlappingClaims(t *testing.T) {
 	}
 }
 
+func claimActionsPermitted(claims []claim.PlayerClaim, actor ClaimActor, action ClaimAction, data any) bool {
+	for _, cl := range claims {
+		if !ClaimActionPermitted(cl, actor, action, data) {
+			return false
+		}
+	}
+	return true
+}
+
 func testClaim() claim.PlayerClaim {
 	return claim.PlayerClaim{
 		ID:           "claim",

--- a/gobds/session/util_claim_action_test.go
+++ b/gobds/session/util_claim_action_test.go
@@ -1,0 +1,338 @@
+package session
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/df-mc/dragonfly/server/world"
+	"github.com/go-gl/mathgl/mgl32"
+	"github.com/sandertv/gophertunnel/minecraft/protocol"
+	gblock "github.com/smell-of-curry/gobds/gobds/block"
+	"github.com/smell-of-curry/gobds/gobds/claim"
+	"github.com/smell-of-curry/gobds/gobds/service"
+)
+
+func TestInsideFeatureUsesClaimDefaultsAndYBounds(t *testing.T) {
+	cl := claim.PlayerClaim{Location: claim.Location{
+		Pos1: claim.Vector2{X: 10, Z: 20},
+		Pos2: claim.Vector2{X: 20, Z: 30},
+	}}
+	if !insideFeature(cl, claim.Feature{}, mgl32.Vec3{15, -64, 25}) {
+		t.Fatal("feature without bounds should use full claim column")
+	}
+
+	from := claim.Vector3{X: 12, Y: 5, Z: 22}
+	to := claim.Vector3{X: 18, Y: 10, Z: 28}
+	feature := claim.Feature{FromLocation: &from, ToLocation: &to}
+	if !insideFeature(cl, feature, mgl32.Vec3{15, 7, 25}) {
+		t.Fatal("position inside explicit feature bounds should be permitted")
+	}
+	if insideFeature(cl, feature, mgl32.Vec3{15, 11, 25}) {
+		t.Fatal("position above explicit feature bounds should be denied")
+	}
+}
+
+func TestFeatureAllowsType(t *testing.T) {
+	filtered := claim.Feature{BlockTypeIDs: []string{"minecraft:stone"}}
+	if !featureAllowsType(filtered, claim.FeatureTypeMineable, "minecraft:stone") {
+		t.Fatal("listed block type should be permitted")
+	}
+	if featureAllowsType(filtered, claim.FeatureTypeMineable, "minecraft:dirt") {
+		t.Fatal("unlisted block type should be denied")
+	}
+	if !featureAllowsType(claim.Feature{}, claim.FeatureTypeMineable, "minecraft:dirt") {
+		t.Fatal("missing type filter should permit every block type")
+	}
+	if featureAllowsType(claim.Feature{BlockTypeIDs: []string{}}, claim.FeatureTypeMineable, "minecraft:stone") {
+		t.Fatal("empty type filter should permit no block types")
+	}
+}
+
+func TestSetupRuntimeIDsSupportsBothNetworkModes(t *testing.T) {
+	world.DefaultBlockRegistry.Finalize()
+	SetupRuntimeIDs()
+	for _, hashed := range []bool{false, true} {
+		block, ok := blockByRuntimeID(denyBlockRuntimeID(hashed), hashed)
+		if !ok {
+			t.Fatalf("deny block not found with hashed IDs set to %v", hashed)
+		}
+		if _, ok := block.(gblock.Deny); !ok {
+			t.Fatalf("deny runtime ID resolved to %T with hashed IDs set to %v", block, hashed)
+		}
+	}
+}
+
+func TestClaimAtSupportsDataDrivenDimensions(t *testing.T) {
+	definitions := []protocol.DimensionDefinition{{
+		Name:          "pokeb:battle_arena",
+		Range:         [2]int32{-64, 320},
+		DimensionType: 1000,
+	}}
+	claims := map[string]claim.PlayerClaim{
+		"arena": {
+			ID:        "arena",
+			OwnerXUID: "owner",
+			Location: claim.Location{
+				Dimension: "pokeb:battle_arena",
+				Pos1:      claim.Vector2{X: 10, Z: 20},
+				Pos2:      claim.Vector2{X: 20, Z: 30},
+			},
+		},
+	}
+	dimension, ok := claimDimensionFromInt(1000, definitions)
+	if !ok || dimension != "pokeb:battle_arena" {
+		t.Fatal("data-driven dimension was not resolved")
+	}
+	claims["second"] = claim.PlayerClaim{
+		ID:        "second",
+		OwnerXUID: "owner",
+		Location: claim.Location{
+			Dimension: "pokeb:battle_arena",
+			Pos1:      claim.Vector2{X: 1, Z: 21},
+			Pos2:      claim.Vector2{X: 2, Z: 22},
+		},
+	}
+	snapshot, err := claim.BuildSnapshot(claims, 1, time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := len(snapshot.Candidates(dimension, 0, 16)); got != 2 {
+		t.Fatalf("expected both claims intersecting chunk, got %d", got)
+	}
+	dimensionRange, ok := dimensionRangeByID(1000, definitions)
+	if !ok || dimensionRange.Min() != -64 || dimensionRange.Max() != 320 {
+		t.Fatalf("unexpected data-driven dimension range: %v, found=%v", dimensionRange, ok)
+	}
+}
+
+func TestClaimPolicyIdentityAndFailOpen(t *testing.T) {
+	cl := testClaim()
+	position := mgl32.Vec3{5, 5, 5}
+	for name, actor := range map[string]ClaimActor{
+		"owner":    {XUID: "owner"},
+		"trusted":  {XUID: "trusted"},
+		"operator": {XUID: "stranger", Operator: true},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if !ClaimActionPermitted(cl, actor, ClaimActionBlockBreak, position) {
+				t.Fatal("privileged actor should be permitted")
+			}
+		})
+	}
+
+	if !ClaimActionPermitted(cl, ClaimActor{}, ClaimActionBlockBreak, position) {
+		t.Fatal("missing XUID must fail open")
+	}
+	if !ClaimActionPermitted(cl, ClaimActor{XUID: "stranger"}, ClaimAction(255), position) {
+		t.Fatal("unsupported action must pass through")
+	}
+	if !ClaimActionPermitted(cl, ClaimActor{XUID: "stranger"}, ClaimActionBlockBreak, "malformed") {
+		t.Fatal("malformed action data must fail open")
+	}
+	for name, malformed := range map[string]claim.PlayerClaim{
+		"empty":             {},
+		"missing id":        {OwnerXUID: "owner", Location: cl.Location},
+		"missing owner":     {ID: "claim", Location: cl.Location},
+		"missing dimension": {ID: "claim", OwnerXUID: "owner"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if !ClaimActionPermitted(malformed, ClaimActor{XUID: "stranger"}, ClaimActionBlockBreak, position) {
+				t.Fatal("malformed claim must fail open")
+			}
+		})
+	}
+}
+
+func TestClaimActionObserveOnlyRecordsForwardedWithoutLookup(t *testing.T) {
+	factory := claim.NewFactory(
+		service.Config{},
+		"TEST",
+		time.Minute,
+		time.Minute,
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+	)
+	s := &Session{claimFactory: factory, claimPrefilter: false}
+	if !s.claimActionPermitted(ClaimActionBlockBreak, "malformed") {
+		t.Fatal("disabled prefilter must preserve forwarding")
+	}
+
+	var output bytes.Buffer
+	factory.Metrics().WriteDelta(&output, time.Minute, nil)
+	var record struct {
+		Seen       []uint64 `json:"seen"`
+		Forwarded  []uint64 `json:"forwarded"`
+		Reasons    []uint64 `json:"reasons"`
+		Candidates uint64   `json:"candidates"`
+	}
+	if err := json.Unmarshal(output.Bytes(), &record); err != nil {
+		t.Fatal(err)
+	}
+	if record.Seen[ClaimActionBlockBreak] != 1 || record.Forwarded[ClaimActionBlockBreak] != 1 {
+		t.Fatalf("observe-only action not recorded as forwarded: %+v", record)
+	}
+	if record.Candidates != 0 {
+		t.Fatalf("observe-only action performed claim lookup: %+v", record)
+	}
+	for _, count := range record.Reasons {
+		if count != 0 {
+			t.Fatalf("observe-only action evaluated claim status: %+v", record)
+		}
+	}
+}
+
+func TestClaimPolicyFeatureParity(t *testing.T) {
+	position := mgl32.Vec3{5, 5, 5}
+	actor := ClaimActor{XUID: "stranger"}
+	tests := []struct {
+		name    string
+		feature claim.Feature
+		action  ClaimAction
+		typeID  string
+	}{
+		{"mineable", claim.Feature{Type: claim.FeatureTypeMineable}, ClaimActionBlockBreak, "minecraft:stone"},
+		{"placeable", claim.Feature{Type: claim.FeatureTypeBlockPlaceable}, ClaimActionBlockPlace, "minecraft:stone"},
+		{"block interactable", claim.Feature{Type: claim.FeatureTypeBlockInteractable}, ClaimActionBlockInteract, "minecraft:chest"},
+		{"entity interactable", claim.Feature{Type: claim.FeatureTypeEntityInteractable}, ClaimActionEntityInteract, "minecraft:armor_stand"},
+		{"entity hurt", claim.Feature{Type: claim.FeatureTypeEntityHurt}, ClaimActionEntityHurt, "minecraft:zombie"},
+		{"drop items", claim.Feature{Type: claim.FeatureTypeDropItems}, ClaimActionItemDrop, "minecraft:stone"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cl := testClaim()
+			cl.Features = []claim.Feature{test.feature}
+			data := claimActionData{position: position, typeID: test.typeID}
+			if !ClaimActionPermitted(cl, actor, test.action, data) {
+				t.Fatal("matching feature should permit action")
+			}
+		})
+	}
+}
+
+func TestClaimPolicyFiltersBoundsAndAdminExceptions(t *testing.T) {
+	actor := ClaimActor{XUID: "stranger"}
+	cl := testClaim()
+	from := claim.Vector3{X: 8, Y: 10, Z: 8}
+	to := claim.Vector3{X: 2, Y: 2, Z: 2}
+	cl.Features = []claim.Feature{{
+		Type:         claim.FeatureTypeMineable,
+		FromLocation: &from,
+		ToLocation:   &to,
+		BlockTypeIDs: []string{"minecraft:stone"},
+	}}
+	if !ClaimActionPermitted(
+		cl,
+		actor,
+		ClaimActionBlockBreak,
+		claimActionData{position: mgl32.Vec3{5, 5, 5}, typeID: "minecraft:stone"},
+	) {
+		t.Fatal("reversed feature bounds and matching filter should permit")
+	}
+	if ClaimActionPermitted(
+		cl,
+		actor,
+		ClaimActionBlockBreak,
+		claimActionData{position: mgl32.Vec3{5, 5, 5}, typeID: "minecraft:dirt"},
+	) {
+		t.Fatal("non-matching block filter should deny")
+	}
+
+	admin := testClaim()
+	admin.OwnerXUID = "*"
+	if !ClaimActionPermitted(admin, actor, ClaimActionEntityInteract, claimActionData{}) {
+		t.Fatal("admin claims should allow entity interaction")
+	}
+	if !ClaimActionPermitted(admin, actor, ClaimActionItemDrop, claimActionData{}) {
+		t.Fatal("admin claims should allow item drops")
+	}
+	if !ClaimActionPermitted(
+		admin,
+		actor,
+		ClaimActionBlockInteract,
+		claimActionData{typeID: "minecraft:ender_chest"},
+	) {
+		t.Fatal("admin claim block exception should be permitted")
+	}
+}
+
+func TestClaimPolicyItemFiltersAndRelease(t *testing.T) {
+	cl := testClaim()
+	cl.Features = []claim.Feature{{
+		Type:        claim.FeatureTypeDropItems,
+		ItemTypeIDs: []string{"minecraft:stone"},
+	}}
+	actor := ClaimActor{XUID: "stranger"}
+	position := mgl32.Vec3{5, 5, 5}
+	if !ClaimActionPermitted(
+		cl,
+		actor,
+		ClaimActionItemDrop,
+		claimActionData{position: position, typeID: "minecraft:stone"},
+	) {
+		t.Fatal("listed item should be droppable")
+	}
+	if ClaimActionPermitted(
+		cl,
+		actor,
+		ClaimActionItemDrop,
+		claimActionData{position: position, typeID: "minecraft:dirt"},
+	) {
+		t.Fatal("unlisted item should not be droppable")
+	}
+	if !ClaimActionPermitted(cl, actor, ClaimActionItemRelease, position) {
+		t.Fatal("item-use release must fail open")
+	}
+	if !ClaimActionPermitted(
+		cl,
+		actor,
+		ClaimActionItemThrow,
+		claimActionData{position: position, typeID: "minecraft:snowball"},
+	) {
+		t.Fatal("click-air throwable use must fail open")
+	}
+}
+
+func TestClaimsAtHandlesReversedAndOverlappingClaims(t *testing.T) {
+	first, second := testClaim(), testClaim()
+	first.Location.Pos1, first.Location.Pos2 = first.Location.Pos2, first.Location.Pos1
+	second.ID = "second"
+	second.Location.Pos1 = claim.Vector2{X: 5, Z: 5}
+	second.Location.Pos2 = claim.Vector2{X: 15, Z: 15}
+	claims := map[string]claim.PlayerClaim{"first": first, "second": second}
+	snapshot, err := claim.BuildSnapshot(claims, 1, time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	candidates := snapshot.Candidates("minecraft:overworld", 7, 7)
+	if len(candidates) != 2 {
+		t.Fatalf("expected both overlapping claims, got %d", len(candidates))
+	}
+	if matched, ambiguous := singleClaimAt(candidates, 7, 7); matched != nil || !ambiguous {
+		t.Fatal("overlap must be ambiguous so proxy can pass through")
+	}
+	first.OwnerXUID = "stranger"
+	if claimActionsPermitted(
+		[]claim.PlayerClaim{first, second},
+		ClaimActor{XUID: "stranger"},
+		ClaimActionBlockBreak,
+		mgl32.Vec3{7, 0, 7},
+	) {
+		t.Fatal("one overlapping denied claim must deny action")
+	}
+}
+
+func testClaim() claim.PlayerClaim {
+	return claim.PlayerClaim{
+		ID:           "claim",
+		OwnerXUID:    "owner",
+		TrustedXUIDS: []string{"trusted"},
+		Location: claim.Location{
+			Dimension: "minecraft:overworld",
+			Pos1:      claim.Vector2{X: 0, Z: 0},
+			Pos2:      claim.Vector2{X: 10, Z: 10},
+		},
+	}
+}

--- a/gobds/user_config.go
+++ b/gobds/user_config.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sandertv/gophertunnel/minecraft"
 	"github.com/sandertv/gophertunnel/minecraft/protocol/login"
 	"github.com/sandertv/gophertunnel/minecraft/resource"
+	"github.com/smell-of-curry/gobds/gobds/claim"
 	"github.com/smell-of-curry/gobds/gobds/cmd"
 	"github.com/smell-of-curry/gobds/gobds/infra"
 	"github.com/smell-of-curry/gobds/gobds/session"
@@ -43,6 +44,12 @@ type UserConfig struct {
 		Enabled    bool
 		MinX, MinZ int32
 		MaxX, MaxZ int32
+	}
+	Claims struct {
+		PrefilterEnabled     bool
+		DenyRenderingEnabled bool
+		PollInterval         string
+		MaxSnapshotAge       string
 	}
 	AFKTimer struct {
 		Enabled         bool
@@ -80,6 +87,10 @@ type UserConfig struct {
 		// treated as VPN/proxy connections. Used for residential ISP
 		// blocks the detection API misclassifies.
 		WhitelistedCIDRs []string
+	}
+	TrafficProtection session.TrafficConfig
+	DuplicateXUID     struct {
+		Enabled bool
 	}
 	Encryption struct {
 		Key string
@@ -277,6 +288,10 @@ func DefaultConfig() UserConfig {
 	c.Network.FlushRate = 20
 
 	c.Border.Enabled = false
+	c.Claims.PrefilterEnabled = false
+	c.Claims.DenyRenderingEnabled = false
+	c.Claims.PollInterval = claim.DefaultPollInterval.String()
+	c.Claims.MaxSnapshotAge = claim.DefaultMaxSnapshotAge.String()
 
 	c.AFKTimer.Enabled = true
 	c.AFKTimer.TimeoutDuration = "10m"
@@ -296,6 +311,9 @@ func DefaultConfig() UserConfig {
 	c.VPNService.URL = "http://ip-api.com/json"
 	// Megalink S.R.L. (Argentina) — residential ISP flagged as proxy by ip-api.
 	c.VPNService.WhitelistedCIDRs = []string{"45.230.64.0/22"}
+
+	c.TrafficProtection = session.DefaultTrafficConfig()
+	c.DuplicateXUID.Enabled = false
 
 	c.Encryption.Key = defaultKey
 	return c

--- a/policy/claim_policy.v1.json
+++ b/policy/claim_policy.v1.json
@@ -1,0 +1,89 @@
+{
+  "schemaVersion": 1,
+  "policyVersion": 1,
+  "cases": [
+    {
+      "name": "stranger denied without feature",
+      "claim": {
+        "claimId": "spawn",
+        "playerXUID": "owner",
+        "location": {
+          "dimension": "minecraft:overworld",
+          "pos1": {"x": 0, "z": 0},
+          "pos2": {"x": 15, "z": 15}
+        },
+        "features": [],
+        "trusts": ["trusted"]
+      },
+      "actor": {"xuid": "stranger", "operator": false},
+      "action": "blockBreak",
+      "position": {"x": 4, "y": 64, "z": 4},
+      "typeId": "minecraft:stone",
+      "permitted": false
+    },
+    {
+      "name": "trusted allowed",
+      "claim": {
+        "claimId": "spawn",
+        "playerXUID": "owner",
+        "location": {
+          "dimension": "minecraft:overworld",
+          "pos1": {"x": 0, "z": 0},
+          "pos2": {"x": 15, "z": 15}
+        },
+        "features": [],
+        "trusts": ["trusted"]
+      },
+      "actor": {"xuid": "trusted", "operator": false},
+      "action": "blockBreak",
+      "position": {"x": 4, "y": 64, "z": 4},
+      "typeId": "minecraft:stone",
+      "permitted": true
+    },
+    {
+      "name": "mineable feature allows listed block",
+      "claim": {
+        "claimId": "spawn",
+        "playerXUID": "owner",
+        "location": {
+          "dimension": "minecraft:overworld",
+          "pos1": {"x": 0, "z": 0},
+          "pos2": {"x": 15, "z": 15}
+        },
+        "features": [
+          {
+            "type": "mineable",
+            "fromLocation": {"x": 2, "y": 60, "z": 2},
+            "toLocation": {"x": 8, "y": 70, "z": 8},
+            "blockTypeIds": ["minecraft:stone"]
+          }
+        ],
+        "trusts": []
+      },
+      "actor": {"xuid": "stranger", "operator": false},
+      "action": "blockBreak",
+      "position": {"x": 4, "y": 64, "z": 4},
+      "typeId": "minecraft:stone",
+      "permitted": true
+    },
+    {
+      "name": "unknown action passes through",
+      "claim": {
+        "claimId": "spawn",
+        "playerXUID": "owner",
+        "location": {
+          "dimension": "minecraft:overworld",
+          "pos1": {"x": 0, "z": 0},
+          "pos2": {"x": 15, "z": 15}
+        },
+        "features": [],
+        "trusts": []
+      },
+      "actor": {"xuid": "stranger", "operator": false},
+      "action": "unknown",
+      "position": {"x": 4, "y": 64, "z": 4},
+      "typeId": "minecraft:stone",
+      "permitted": true
+    }
+  ]
+}

--- a/policy/claim_policy.v1.json
+++ b/policy/claim_policy.v1.json
@@ -65,25 +65,6 @@
       "position": {"x": 4, "y": 64, "z": 4},
       "typeId": "minecraft:stone",
       "permitted": true
-    },
-    {
-      "name": "unknown action passes through",
-      "claim": {
-        "claimId": "spawn",
-        "playerXUID": "owner",
-        "location": {
-          "dimension": "minecraft:overworld",
-          "pos1": {"x": 0, "z": 0},
-          "pos2": {"x": 15, "z": 15}
-        },
-        "features": [],
-        "trusts": []
-      },
-      "actor": {"xuid": "stranger", "operator": false},
-      "action": "unknown",
-      "position": {"x": 4, "y": 64, "z": 4},
-      "typeId": "minecraft:stone",
-      "permitted": true
     }
   ]
 }


### PR DESCRIPTION
Introduce a full claim proxy and traffic-protection system plus related session/server/entity improvements. Added a claim package (factory, service, snapshot, model, metrics, tests) with HTTP revalidation, immutable snapshots, fail-open semantics, and policy golden fixtures. Implement deny block, deny-rendering of subchunks, corrective chunk logic, and claim decision helpers used by many new session packet handlers. Add per-session traffic rate limiting, traffic metrics, XUID reservation to prevent duplicate logins, improved entity tracking, config fields/defaults, and numerous tests. CI updated to run go test -race and policy JSON included in repo.

Needs: https://github.com/smell-of-curry/bds-manager/pull/10 and https://github.com/smell-of-curry/pokebedrock-beh/pull/670

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable claim-based protection for block interactions, rendering, item actions, and feature-specific permissions.
  * Added claim snapshot refreshing, stale-data handling, and policy configuration.
  * Added traffic protection limits for chat, commands, forms, and inventory actions.
  * Added duplicate-login prevention for simultaneous sessions.
  * Added entity tracking improvements and support for updated game-state events.
  * Added periodic traffic and claim metrics output.

* **Bug Fixes**
  * Improved handling of malformed packets, invalid claims, authentication errors, and service interruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->